### PR TITLE
Change name of packages to be under @redhat-cloud-services org

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "root",
+  "name": "@redhat-cloud-services/insights-common-typescript-root",
   "private": true,
   "scripts": {
     "build": "lerna run build",

--- a/packages/insights-common-typescript/.gitignore
+++ b/packages/insights-common-typescript/.gitignore
@@ -1,0 +1,2 @@
+package-lock.json
+yarn.lock

--- a/packages/insights-common-typescript/.npmignore
+++ b/packages/insights-common-typescript/.npmignore
@@ -1,0 +1,8 @@
+config
+test
+src/
+codecov.yml
+jest.config.json
+tsconfig.json
+jest.config.js
+!lib

--- a/packages/insights-common-typescript/README.md
+++ b/packages/insights-common-typescript/README.md
@@ -1,0 +1,1 @@
+# @redhat-cloud-services/insights-common-typescript

--- a/packages/insights-common-typescript/package.json
+++ b/packages/insights-common-typescript/package.json
@@ -1,10 +1,13 @@
 {
-  "name": "insights-common-typescript",
-  "version": "1.0.0",
+  "name": "@redhat-cloud-services/insights-common-typescript",
+  "version": "0.0.1",
   "private": false,
   "license": "Apache-2.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsc",
     "lint": "eslint --ext js,ts,tsx config src",


### PR DESCRIPTION
Changed names, `publishConfig` and some npmignore so we don't publish all `src` etc. 