### PR TITLE
Allow karma support

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "formik": "^2.1.4",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^24.9.0",
+    "jest-mock": "^26.1.0",
     "lerna": "^3.22.1",
     "lodash": "^4.17.15",
     "npm-run-all": "^4.1.5",

--- a/packages/insights-common-typescript/package.json
+++ b/packages/insights-common-typescript/package.json
@@ -35,6 +35,7 @@
     "axios": "^0.19.2",
     "csx": "^10.0.1",
     "formik": "^2.1.4",
+    "jest-mock": "^26.1.0",
     "lodash": "^4.17.15",
     "react": "^16.13.1",
     "react-content-loader": "^3.4.2",

--- a/packages/insights-common-typescript/src/utils/Insights.ts
+++ b/packages/insights-common-typescript/src/utils/Insights.ts
@@ -3,6 +3,7 @@
 // Is possible that there is something wrong and/or missing, but as I was using this on more than one file it seems like
 // a good idea to have all the usage in a single file and define a common interface to keep track of it.
 // It would be even better to add the typings to the common code or to @types.
+import jestMock from 'jest-mock';
 
 interface Entitlement {
     is_entitled: boolean;
@@ -49,38 +50,42 @@ export type InsightsType = {
     };
 };
 
-declare const insights: InsightsType;
+interface Window {
+    insights: InsightsType;
+}
+
+declare const window: Window;
 
 let insightPromise: Promise<InsightsType>;
 
 export const waitForInsights = (): Promise<InsightsType> => {
     if (!insightPromise) {
         insightPromise = new Promise<InsightsType>(async (resolve) => {
-            while (!global.hasOwnProperty('insights')) {
+            while (!window.hasOwnProperty('insights')) {
                 await new Promise(timeout => setTimeout(timeout, 250));
             }
 
-            resolve(insights);
+            resolve(window.insights);
         });
     }
 
     return insightPromise;
 };
 
-export const getInsights = (): InsightsType => insights;
+export const getInsights = (): InsightsType => window.insights;
 
 export const mockInsights = (mock?: InsightsType) => {
-    (global as any).insights = mock || {
+    window.insights = mock || {
         chrome: {
-            init: jest.fn(),
-            identifyApp: jest.fn((_appId: string) => Promise.resolve()),
-            on: jest.fn((type: string, callback: ((event: any) => void)) => {
+            init: jestMock.fn(),
+            identifyApp: jestMock.fn((_appId: string) => Promise.resolve()),
+            on: jestMock.fn((type: string, callback: ((event: any) => void)) => {
                 callback(new Event('fake'));
             }),
             isProd: false,
-            isBeta: jest.fn(() => true),
+            isBeta: jestMock.fn(() => true),
             auth: {
-                getUser: jest.fn(() => Promise.resolve({
+                getUser: jestMock.fn(() => Promise.resolve({
                     identity: {
                         account_number: '123456',
                         internal: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -489,6 +489,16 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jest/types@^26.1.0":
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.1.0.tgz#f8afaaaeeb23b5cad49dd1f7779689941dcb6057"
+  integrity sha512-GXigDDsp6ZlNMhXQDeuy/iYCDsRIHJabWtDzvnn36+aqFfG14JmFV0e/iXxY4SP9vbXSiPNOWdehU5MeqrYHBQ==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^1.1.1"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@lerna/add@3.21.0":
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/@lerna/add/-/add-3.21.0.tgz#27007bde71cc7b0a2969ab3c2f0ae41578b4577b"
@@ -2933,7 +2943,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.1.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -6864,6 +6874,13 @@ jest-mock@^24.9.0:
   integrity sha512-3BEYN5WbSq9wd+SyLDES7AHnjH9A/ROBwmz7l2y+ol+NtSFO8DYiEBzoO1CeFc9a8DYy10EO4dDFVv/wN3zl1w==
   dependencies:
     "@jest/types" "^24.9.0"
+
+jest-mock@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-26.1.0.tgz#80d8286da1f05a345fbad1bfd6fa49a899465d3d"
+  integrity sha512-1Rm8EIJ3ZFA8yCIie92UbxZWj9SuVmUGcyhLHyAhY6WI3NIct38nVcfOPWhJteqSn8V8e3xOMha9Ojfazfpovw==
+  dependencies:
+    "@jest/types" "^26.1.0"
 
 jest-pnp-resolver@^1.2.1:
   version "1.2.2"


### PR DESCRIPTION
 - Using jestMock.fn instead of jest.fn
 - Reading `insights` always from `window`