### PR TITLE
ci: on deploy, checkout all the repo to determine versioning

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
           node-version: '12'


### PR DESCRIPTION
Hopefully, this is the last thing to configure the automatic deployment to actually bump the versions depending on the commit log.