### PR TITLE
feat: adding no-strict mode to allow unknown keys in the response

### DIFF
--- a/packages/openapi2typescript-cli/src/cli/Program.ts
+++ b/packages/openapi2typescript-cli/src/cli/Program.ts
@@ -43,6 +43,12 @@ export const getProgram = () => {
         'Skip the types, useful for js building',
         false
     )
+    .option(
+        '--no-strict',
+        'Whether or not to use the non-strict checking of zod. \n' +
+        'If --no-strict is set, the unknown keys are ignored instead of counting as an error.\n' +
+        'This could be useful to avoid failing if a new schema adds new properties to objects.'
+    )
     .requiredOption(
         '-i, --input <openapijson-file-or-url>',
         'URL or local path to the openapi.json file.'

--- a/packages/openapi2typescript-cli/src/core/ApiBase.ts
+++ b/packages/openapi2typescript-cli/src/core/ApiBase.ts
@@ -14,6 +14,7 @@ import assertNever from 'assert-never';
 
 export interface Options {
     skipTypes: boolean;
+    strict: boolean;
 }
 
 export class ApiBase {
@@ -27,6 +28,7 @@ export class ApiBase {
         this.buffer = buffer;
         this.options = {
             skipTypes: false,
+            strict: true,
             ...options
         };
         this.localBuffer = [];
@@ -53,6 +55,9 @@ export class ApiBase {
                 this.appendTemp('z.object({\n');
                 this.properties(schema.properties);
                 this.appendTemp('})\n');
+                if (!this.options.strict) {
+                    this.appendTemp('.nonstrict()');
+                }
             }
 
             if (schema.properties && schema.additionalProperties) {

--- a/packages/openapi2typescript-cli/src/main.ts
+++ b/packages/openapi2typescript-cli/src/main.ts
@@ -19,6 +19,7 @@ export interface Options {
     actionGenerator: ActionGeneratorType;
     addEslintDisable: boolean;
     skipTypes: boolean;
+    strict: boolean;
 }
 
 export const execute = async (options: Options) => {

--- a/packages/openapi2typescript-cli/tests/cli/Program.test.ts
+++ b/packages/openapi2typescript-cli/tests/cli/Program.test.ts
@@ -7,7 +7,31 @@ describe('src/Program', () => {
             skipPostProcess: false,
             actionGenerator: ActionGeneratorType.NONE,
             addEslintDisable: false,
-            skipTypes: false
+            skipTypes: false,
+            strict: true
+        });
+    });
+
+    it('Allows to override default values', () => {
+        expect(getProgram().parse([
+            '--skip-post-process',
+            '--action-generator',
+            'react-fetching-library',
+            '--add-eslint-disable',
+            '--skip-types',
+            '--no-strict',
+            '-i',
+            'input',
+            '-o',
+            'output'
+        ], {
+            from: 'user'
+        })).toMatchObject({
+            skipPostProcess: true,
+            actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY,
+            addEslintDisable: true,
+            skipTypes: true,
+            strict: false
         });
     });
 });

--- a/packages/openapi2typescript-cli/tests/main.test.ts
+++ b/packages/openapi2typescript-cli/tests/main.test.ts
@@ -33,10 +33,43 @@ describe('src/cli/schema', () => {
                 skipPostProcess: false,
                 addEslintDisable: true,
                 actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY,
-                skipTypes: true
+                skipTypes: true,
+                strict: true
             }).then(() => {
                 expect(existsSync(`${tempSchemaDir}/Generated.ts`)).toBeTruthy();
                 expect(readFileSync(`${tempSchemaDir}/Generated.ts`).toString()).toMatchSnapshot();
+
+            });
+        });
+
+        it('sets objects to nonstrict if strict is false', () => {
+            return execute({
+                input: filename,
+                output: tempSchemaDir,
+                skipPostProcess: false,
+                addEslintDisable: true,
+                actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY,
+                skipTypes: true,
+                strict: false
+            }).then(() => {
+                expect(existsSync(`${tempSchemaDir}/Generated.ts`)).toBeTruthy();
+                expect(readFileSync(`${tempSchemaDir}/Generated.ts`).toString()).toContain('.nonstrict()');
+
+            });
+        });
+
+        it('do not set objects to nonstrict if strict is true', () => {
+            return execute({
+                input: filename,
+                output: tempSchemaDir,
+                skipPostProcess: false,
+                addEslintDisable: true,
+                actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY,
+                skipTypes: true,
+                strict: true
+            }).then(() => {
+                expect(existsSync(`${tempSchemaDir}/Generated.ts`)).toBeTruthy();
+                expect(readFileSync(`${tempSchemaDir}/Generated.ts`).toString()).not.toContain('.nonstrict()');
 
             });
         });
@@ -53,7 +86,8 @@ describe('src/cli/schema', () => {
                 addEslintDisable: true,
                 skipPostProcess: false,
                 skipTypes: false,
-                actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY
+                actionGenerator: ActionGeneratorType.REACT_FETCHING_LIBRARY,
+                strict: true
             }).then(() => {
                 (fetchMock as any).restore();
                 expect(existsSync(`${tempSchemaDir}/Generated.ts`)).toBeTruthy();


### PR DESCRIPTION
Uses zod.nonstrict method of objects to prevent the validation from failing when keys that are not part of the known schema are found.