### PR TITLE
fix: uses the function name of the schema instead of the type

### DIFF
--- a/packages/openapi2typescript-cli/src/core/ApiBase.ts
+++ b/packages/openapi2typescript-cli/src/core/ApiBase.ts
@@ -252,7 +252,8 @@ export class ApiBase {
                 this.appendTemp('z.lazy(() => ');
             }
 
-            this.appendTemp(schema.typeName);
+            // This allows to use an schema that hasn't been defined yet
+            this.appendTemp(`${this.functionName(schema)}()`);
 
             if (schema.hasLoop) {
                 this.appendTemp(')');

--- a/packages/openapi2typescript-cli/tests/__snapshots__/main.test.ts.snap
+++ b/packages/openapi2typescript-cli/tests/__snapshots__/main.test.ts.snap
@@ -144,7 +144,9 @@ const EndpointServiceGetEndpointsParamType = z.string();
 type EndpointServiceGetEndpointsParamType = z.infer<
   typeof EndpointServiceGetEndpointsParamType
 >;
-const EndpointServiceGetEndpointsParamResponse200 = z.array(Endpoint);
+const EndpointServiceGetEndpointsParamResponse200 = z.array(
+    zodSchemaEndpoint()
+);
 type EndpointServiceGetEndpointsParamResponse200 = z.infer<
   typeof EndpointServiceGetEndpointsParamResponse200
 >;
@@ -437,7 +439,7 @@ export const actionEndpointServiceDisableEndpoint = (
 
 // GET /endpoints/{id}/history
 const EndpointServiceGetEndpointHistoryParamResponse200 = z.array(
-    NotificationHistory
+    zodSchemaNotificationHistory()
 );
 type EndpointServiceGetEndpointHistoryParamResponse200 = z.infer<
   typeof EndpointServiceGetEndpointHistoryParamResponse200
@@ -590,7 +592,7 @@ export function zodSchemaNewCookie() {
         value: z.string().optional().nullable(),
         version: z.number().int().optional().nullable(),
         comment: z.string().optional().nullable(),
-        expiry: Date.optional().nullable(),
+        expiry: zodSchemaDate().optional().nullable(),
         httpOnly: z.boolean().optional().nullable(),
         maxAge: z.number().int().optional().nullable(),
         secure: z.boolean().optional().nullable()
@@ -598,7 +600,7 @@ export function zodSchemaNewCookie() {
 }
 
 export function zodSchemaMapStringNewCookie() {
-    return z.record(NewCookie);
+    return z.record(zodSchemaNewCookie());
 }
 
 export function zodSchemaDate() {
@@ -624,31 +626,31 @@ export function zodSchemaLocale() {
         displayName: z.string().optional().nullable(),
         displayScript: z.string().optional().nullable(),
         displayVariant: z.string().optional().nullable(),
-        extensionKeys: SetCharacter.optional().nullable(),
+        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
         iSO3Country: z.string().optional().nullable(),
         iSO3Language: z.string().optional().nullable(),
         language: z.string().optional().nullable(),
         script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: SetString.optional().nullable(),
-        unicodeLocaleKeys: SetString.optional().nullable(),
+        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
         variant: z.string().optional().nullable()
     });
 }
 
 export function zodSchemaLink() {
     return z.object({
-        params: MapStringString.optional().nullable(),
+        params: zodSchemaMapStringString().optional().nullable(),
         rel: z.string().optional().nullable(),
-        rels: ListString.optional().nullable(),
+        rels: zodSchemaListString().optional().nullable(),
         title: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
-        uri: URI.optional().nullable(),
-        uriBuilder: UriBuilder.optional().nullable()
+        uri: zodSchemaURI().optional().nullable(),
+        uriBuilder: zodSchemaUriBuilder().optional().nullable()
     });
 }
 
 export function zodSchemaSetLink() {
-    return z.array(Link);
+    return z.array(zodSchemaLink());
 }
 
 export function zodSchemaURI() {
@@ -657,7 +659,7 @@ export function zodSchemaURI() {
 
 export function zodSchemaMediaType() {
     return z.object({
-        parameters: MapStringString.optional().nullable(),
+        parameters: zodSchemaMapStringString().optional().nullable(),
         subtype: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
         wildcardSubtype: z.boolean().optional().nullable(),
@@ -667,7 +669,7 @@ export function zodSchemaMediaType() {
 
 export function zodSchemaStatusType() {
     return z.object({
-        family: Family.optional().nullable(),
+        family: zodSchemaFamily().optional().nullable(),
         reasonPhrase: z.string().optional().nullable(),
         statusCode: z.number().int().optional().nullable()
     });
@@ -706,22 +708,22 @@ export function zodSchemaSetCharacter() {
 
 export function zodSchemaResponse() {
     return z.object({
-        allowedMethods: SetString.optional().nullable(),
-        cookies: MapStringNewCookie.optional().nullable(),
-        date: Date.optional().nullable(),
+        allowedMethods: zodSchemaSetString().optional().nullable(),
+        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+        date: zodSchemaDate().optional().nullable(),
         entity: z.unknown().optional().nullable(),
-        entityTag: EntityTag.optional().nullable(),
-        headers: MultivaluedMapStringObject.optional().nullable(),
-        language: Locale.optional().nullable(),
-        lastModified: Date.optional().nullable(),
+        entityTag: zodSchemaEntityTag().optional().nullable(),
+        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+        language: zodSchemaLocale().optional().nullable(),
+        lastModified: zodSchemaDate().optional().nullable(),
         length: z.number().int().optional().nullable(),
-        links: SetLink.optional().nullable(),
-        location: URI.optional().nullable(),
-        mediaType: MediaType.optional().nullable(),
-        metadata: MultivaluedMapStringObject.optional().nullable(),
+        links: zodSchemaSetLink().optional().nullable(),
+        location: zodSchemaURI().optional().nullable(),
+        mediaType: zodSchemaMediaType().optional().nullable(),
+        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
         status: z.number().int().optional().nullable(),
-        statusInfo: StatusType.optional().nullable(),
-        stringHeaders: MultivaluedMapStringString.optional().nullable()
+        statusInfo: zodSchemaStatusType().optional().nullable(),
+        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
     });
 }
 
@@ -742,9 +744,9 @@ export function zodSchemaHttpType() {
 
 export function zodSchemaWebhookAttributes() {
     return z.object({
-        basic_authentication: BasicAuthentication.optional().nullable(),
+        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
         disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(HttpType, z.enum([ 'GET', 'POST', 'PUT' ])),
+        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
         secret_token: z.string().optional().nullable(),
         url: z.string()
     });
@@ -760,55 +762,58 @@ export function zodSchemaEndpointType() {
 
 export function zodSchemaEndpoint() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
         enabled: z.boolean().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
         properties: z
-        .union([ WebhookAttributes, EmailAttributes ])
+        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
         .optional()
         .nullable(),
-        type: z.intersection(EndpointType, z.enum([ 'webhook', 'email', 'default' ])),
-        updated: Date.optional().nullable()
+        type: z.intersection(
+            zodSchemaEndpointType(),
+            z.enum([ 'webhook', 'email', 'default' ])
+        ),
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaApplication() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
-        eventTypes: SetEventType.optional().nullable(),
-        id: UUID.optional().nullable(),
+        eventTypes: zodSchemaSetEventType().optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
-        updated: Date.optional().nullable()
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaSetEndpoint() {
-    return z.array(Endpoint);
+    return z.array(zodSchemaEndpoint());
 }
 
 export function zodSchemaEventType() {
     return z.object({
         application: z
-        .lazy(() => Application)
+        .lazy(() => zodSchemaApplication())
         .optional()
         .nullable(),
         description: z.string(),
-        endpoints: SetEndpoint.optional().nullable(),
+        endpoints: zodSchemaSetEndpoint().optional().nullable(),
         id: z.number().int().optional().nullable(),
         name: z.string()
     });
 }
 
 export function zodSchemaSetEventType() {
-    return z.array(EventType);
+    return z.array(zodSchemaEventType());
 }
 
 export function zodSchemaNotification() {
     return z.object({
-        endpoint: Endpoint.optional().nullable(),
+        endpoint: zodSchemaEndpoint().optional().nullable(),
         payload: z.unknown().optional().nullable(),
         tenant: z.string().optional().nullable()
     });
@@ -820,9 +825,9 @@ export function zodSchemaJsonObject() {
 
 export function zodSchemaNotificationHistory() {
     return z.object({
-        created: Date.optional().nullable(),
-        details: JsonObject.optional().nullable(),
-        endpointId: UUID.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
+        details: zodSchemaJsonObject().optional().nullable(),
+        endpointId: zodSchemaUUID().optional().nullable(),
         id: z.number().int().optional().nullable(),
         invocationResult: z.boolean().optional().nullable(),
         invocationTime: z.number().int().optional().nullable()
@@ -914,7 +919,9 @@ const EndpointServiceGetEndpointsParamOffset = z.number().int();
 const EndpointServiceGetEndpointsParamPageNumber = z.number().int();
 const EndpointServiceGetEndpointsParamSortBy = z.string();
 const EndpointServiceGetEndpointsParamType = z.string();
-const EndpointServiceGetEndpointsParamResponse200 = z.array(Endpoint);
+const EndpointServiceGetEndpointsParamResponse200 = z.array(
+    zodSchemaEndpoint()
+);
 /*
  Params
 'active'?:EndpointServiceGetEndpointsParamActive,
@@ -1109,7 +1116,7 @@ export const actionEndpointServiceDisableEndpoint = (params) => {
 
 // GET /endpoints/{id}/history
 const EndpointServiceGetEndpointHistoryParamResponse200 = z.array(
-    NotificationHistory
+    zodSchemaNotificationHistory()
 );
 /*
  Params
@@ -1212,7 +1219,7 @@ export function zodSchemaNewCookie() {
         value: z.string().optional().nullable(),
         version: z.number().int().optional().nullable(),
         comment: z.string().optional().nullable(),
-        expiry: Date.optional().nullable(),
+        expiry: zodSchemaDate().optional().nullable(),
         httpOnly: z.boolean().optional().nullable(),
         maxAge: z.number().int().optional().nullable(),
         secure: z.boolean().optional().nullable()
@@ -1220,7 +1227,7 @@ export function zodSchemaNewCookie() {
 }
 
 export function zodSchemaMapStringNewCookie() {
-    return z.record(NewCookie);
+    return z.record(zodSchemaNewCookie());
 }
 
 export function zodSchemaDate() {
@@ -1246,31 +1253,31 @@ export function zodSchemaLocale() {
         displayName: z.string().optional().nullable(),
         displayScript: z.string().optional().nullable(),
         displayVariant: z.string().optional().nullable(),
-        extensionKeys: SetCharacter.optional().nullable(),
+        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
         iSO3Country: z.string().optional().nullable(),
         iSO3Language: z.string().optional().nullable(),
         language: z.string().optional().nullable(),
         script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: SetString.optional().nullable(),
-        unicodeLocaleKeys: SetString.optional().nullable(),
+        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
         variant: z.string().optional().nullable()
     });
 }
 
 export function zodSchemaLink() {
     return z.object({
-        params: MapStringString.optional().nullable(),
+        params: zodSchemaMapStringString().optional().nullable(),
         rel: z.string().optional().nullable(),
-        rels: ListString.optional().nullable(),
+        rels: zodSchemaListString().optional().nullable(),
         title: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
-        uri: URI.optional().nullable(),
-        uriBuilder: UriBuilder.optional().nullable()
+        uri: zodSchemaURI().optional().nullable(),
+        uriBuilder: zodSchemaUriBuilder().optional().nullable()
     });
 }
 
 export function zodSchemaSetLink() {
-    return z.array(Link);
+    return z.array(zodSchemaLink());
 }
 
 export function zodSchemaURI() {
@@ -1279,7 +1286,7 @@ export function zodSchemaURI() {
 
 export function zodSchemaMediaType() {
     return z.object({
-        parameters: MapStringString.optional().nullable(),
+        parameters: zodSchemaMapStringString().optional().nullable(),
         subtype: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
         wildcardSubtype: z.boolean().optional().nullable(),
@@ -1289,7 +1296,7 @@ export function zodSchemaMediaType() {
 
 export function zodSchemaStatusType() {
     return z.object({
-        family: Family.optional().nullable(),
+        family: zodSchemaFamily().optional().nullable(),
         reasonPhrase: z.string().optional().nullable(),
         statusCode: z.number().int().optional().nullable()
     });
@@ -1328,22 +1335,22 @@ export function zodSchemaSetCharacter() {
 
 export function zodSchemaResponse() {
     return z.object({
-        allowedMethods: SetString.optional().nullable(),
-        cookies: MapStringNewCookie.optional().nullable(),
-        date: Date.optional().nullable(),
+        allowedMethods: zodSchemaSetString().optional().nullable(),
+        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+        date: zodSchemaDate().optional().nullable(),
         entity: z.unknown().optional().nullable(),
-        entityTag: EntityTag.optional().nullable(),
-        headers: MultivaluedMapStringObject.optional().nullable(),
-        language: Locale.optional().nullable(),
-        lastModified: Date.optional().nullable(),
+        entityTag: zodSchemaEntityTag().optional().nullable(),
+        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+        language: zodSchemaLocale().optional().nullable(),
+        lastModified: zodSchemaDate().optional().nullable(),
         length: z.number().int().optional().nullable(),
-        links: SetLink.optional().nullable(),
-        location: URI.optional().nullable(),
-        mediaType: MediaType.optional().nullable(),
-        metadata: MultivaluedMapStringObject.optional().nullable(),
+        links: zodSchemaSetLink().optional().nullable(),
+        location: zodSchemaURI().optional().nullable(),
+        mediaType: zodSchemaMediaType().optional().nullable(),
+        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
         status: z.number().int().optional().nullable(),
-        statusInfo: StatusType.optional().nullable(),
-        stringHeaders: MultivaluedMapStringString.optional().nullable()
+        statusInfo: zodSchemaStatusType().optional().nullable(),
+        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
     });
 }
 
@@ -1364,9 +1371,9 @@ export function zodSchemaHttpType() {
 
 export function zodSchemaWebhookAttributes() {
     return z.object({
-        basic_authentication: BasicAuthentication.optional().nullable(),
+        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
         disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(HttpType, z.enum([ 'GET', 'POST', 'PUT' ])),
+        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
         secret_token: z.string().optional().nullable(),
         url: z.string()
     });
@@ -1382,55 +1389,58 @@ export function zodSchemaEndpointType() {
 
 export function zodSchemaEndpoint() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
         enabled: z.boolean().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
         properties: z
-        .union([ WebhookAttributes, EmailAttributes ])
+        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
         .optional()
         .nullable(),
-        type: z.intersection(EndpointType, z.enum([ 'webhook', 'email', 'default' ])),
-        updated: Date.optional().nullable()
+        type: z.intersection(
+            zodSchemaEndpointType(),
+            z.enum([ 'webhook', 'email', 'default' ])
+        ),
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaApplication() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
-        eventTypes: SetEventType.optional().nullable(),
-        id: UUID.optional().nullable(),
+        eventTypes: zodSchemaSetEventType().optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
-        updated: Date.optional().nullable()
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaSetEndpoint() {
-    return z.array(Endpoint);
+    return z.array(zodSchemaEndpoint());
 }
 
 export function zodSchemaEventType() {
     return z.object({
         application: z
-        .lazy(() => Application)
+        .lazy(() => zodSchemaApplication())
         .optional()
         .nullable(),
         description: z.string(),
-        endpoints: SetEndpoint.optional().nullable(),
+        endpoints: zodSchemaSetEndpoint().optional().nullable(),
         id: z.number().int().optional().nullable(),
         name: z.string()
     });
 }
 
 export function zodSchemaSetEventType() {
-    return z.array(EventType);
+    return z.array(zodSchemaEventType());
 }
 
 export function zodSchemaNotification() {
     return z.object({
-        endpoint: Endpoint.optional().nullable(),
+        endpoint: zodSchemaEndpoint().optional().nullable(),
         payload: z.unknown().optional().nullable(),
         tenant: z.string().optional().nullable()
     });
@@ -1442,9 +1452,9 @@ export function zodSchemaJsonObject() {
 
 export function zodSchemaNotificationHistory() {
     return z.object({
-        created: Date.optional().nullable(),
-        details: JsonObject.optional().nullable(),
-        endpointId: UUID.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
+        details: zodSchemaJsonObject().optional().nullable(),
+        endpointId: zodSchemaUUID().optional().nullable(),
         id: z.number().int().optional().nullable(),
         invocationResult: z.boolean().optional().nullable(),
         invocationTime: z.number().int().optional().nullable()
@@ -1574,7 +1584,7 @@ export type NotificationHistory = z.infer<typeof NotificationHistory>;
 
 // GET /notifications/defaults
 const NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.array(
-    Endpoint
+    zodSchemaEndpoint()
 );
 type NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.infer<
   typeof NotificationServiceGetEndpointsForDefaultsParamResponse200
@@ -1680,7 +1690,9 @@ const NotificationServiceGetEventTypesParamSortBy = z.string();
 type NotificationServiceGetEventTypesParamSortBy = z.infer<
   typeof NotificationServiceGetEventTypesParamSortBy
 >;
-const NotificationServiceGetEventTypesParamResponse200 = z.array(EventType);
+const NotificationServiceGetEventTypesParamResponse200 = z.array(
+    zodSchemaEventType()
+);
 type NotificationServiceGetEventTypesParamResponse200 = z.infer<
   typeof NotificationServiceGetEventTypesParamResponse200
 >;
@@ -1758,7 +1770,9 @@ const NotificationServiceGetLinkedEndpointsParamSortBy = z.string();
 type NotificationServiceGetLinkedEndpointsParamSortBy = z.infer<
   typeof NotificationServiceGetLinkedEndpointsParamSortBy
 >;
-const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(Endpoint);
+const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(
+    zodSchemaEndpoint()
+);
 type NotificationServiceGetLinkedEndpointsParamResponse200 = z.infer<
   typeof NotificationServiceGetLinkedEndpointsParamResponse200
 >;
@@ -1903,7 +1917,7 @@ export const actionNotificationServiceUnlinkEndpointFromEventType = (
 
 // GET /notifications/updates
 const NotificationServiceGetNotificationUpdatesParamResponse200 = z.array(
-    Notification
+    zodSchemaNotification()
 );
 type NotificationServiceGetNotificationUpdatesParamResponse200 = z.infer<
   typeof NotificationServiceGetNotificationUpdatesParamResponse200
@@ -1982,7 +1996,7 @@ export function zodSchemaNewCookie() {
         value: z.string().optional().nullable(),
         version: z.number().int().optional().nullable(),
         comment: z.string().optional().nullable(),
-        expiry: Date.optional().nullable(),
+        expiry: zodSchemaDate().optional().nullable(),
         httpOnly: z.boolean().optional().nullable(),
         maxAge: z.number().int().optional().nullable(),
         secure: z.boolean().optional().nullable()
@@ -1990,7 +2004,7 @@ export function zodSchemaNewCookie() {
 }
 
 export function zodSchemaMapStringNewCookie() {
-    return z.record(NewCookie);
+    return z.record(zodSchemaNewCookie());
 }
 
 export function zodSchemaDate() {
@@ -2016,31 +2030,31 @@ export function zodSchemaLocale() {
         displayName: z.string().optional().nullable(),
         displayScript: z.string().optional().nullable(),
         displayVariant: z.string().optional().nullable(),
-        extensionKeys: SetCharacter.optional().nullable(),
+        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
         iSO3Country: z.string().optional().nullable(),
         iSO3Language: z.string().optional().nullable(),
         language: z.string().optional().nullable(),
         script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: SetString.optional().nullable(),
-        unicodeLocaleKeys: SetString.optional().nullable(),
+        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
         variant: z.string().optional().nullable()
     });
 }
 
 export function zodSchemaLink() {
     return z.object({
-        params: MapStringString.optional().nullable(),
+        params: zodSchemaMapStringString().optional().nullable(),
         rel: z.string().optional().nullable(),
-        rels: ListString.optional().nullable(),
+        rels: zodSchemaListString().optional().nullable(),
         title: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
-        uri: URI.optional().nullable(),
-        uriBuilder: UriBuilder.optional().nullable()
+        uri: zodSchemaURI().optional().nullable(),
+        uriBuilder: zodSchemaUriBuilder().optional().nullable()
     });
 }
 
 export function zodSchemaSetLink() {
-    return z.array(Link);
+    return z.array(zodSchemaLink());
 }
 
 export function zodSchemaURI() {
@@ -2049,7 +2063,7 @@ export function zodSchemaURI() {
 
 export function zodSchemaMediaType() {
     return z.object({
-        parameters: MapStringString.optional().nullable(),
+        parameters: zodSchemaMapStringString().optional().nullable(),
         subtype: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
         wildcardSubtype: z.boolean().optional().nullable(),
@@ -2059,7 +2073,7 @@ export function zodSchemaMediaType() {
 
 export function zodSchemaStatusType() {
     return z.object({
-        family: Family.optional().nullable(),
+        family: zodSchemaFamily().optional().nullable(),
         reasonPhrase: z.string().optional().nullable(),
         statusCode: z.number().int().optional().nullable()
     });
@@ -2098,22 +2112,22 @@ export function zodSchemaSetCharacter() {
 
 export function zodSchemaResponse() {
     return z.object({
-        allowedMethods: SetString.optional().nullable(),
-        cookies: MapStringNewCookie.optional().nullable(),
-        date: Date.optional().nullable(),
+        allowedMethods: zodSchemaSetString().optional().nullable(),
+        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+        date: zodSchemaDate().optional().nullable(),
         entity: z.unknown().optional().nullable(),
-        entityTag: EntityTag.optional().nullable(),
-        headers: MultivaluedMapStringObject.optional().nullable(),
-        language: Locale.optional().nullable(),
-        lastModified: Date.optional().nullable(),
+        entityTag: zodSchemaEntityTag().optional().nullable(),
+        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+        language: zodSchemaLocale().optional().nullable(),
+        lastModified: zodSchemaDate().optional().nullable(),
         length: z.number().int().optional().nullable(),
-        links: SetLink.optional().nullable(),
-        location: URI.optional().nullable(),
-        mediaType: MediaType.optional().nullable(),
-        metadata: MultivaluedMapStringObject.optional().nullable(),
+        links: zodSchemaSetLink().optional().nullable(),
+        location: zodSchemaURI().optional().nullable(),
+        mediaType: zodSchemaMediaType().optional().nullable(),
+        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
         status: z.number().int().optional().nullable(),
-        statusInfo: StatusType.optional().nullable(),
-        stringHeaders: MultivaluedMapStringString.optional().nullable()
+        statusInfo: zodSchemaStatusType().optional().nullable(),
+        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
     });
 }
 
@@ -2134,9 +2148,9 @@ export function zodSchemaHttpType() {
 
 export function zodSchemaWebhookAttributes() {
     return z.object({
-        basic_authentication: BasicAuthentication.optional().nullable(),
+        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
         disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(HttpType, z.enum([ 'GET', 'POST', 'PUT' ])),
+        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
         secret_token: z.string().optional().nullable(),
         url: z.string()
     });
@@ -2152,55 +2166,58 @@ export function zodSchemaEndpointType() {
 
 export function zodSchemaEndpoint() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
         enabled: z.boolean().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
         properties: z
-        .union([ WebhookAttributes, EmailAttributes ])
+        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
         .optional()
         .nullable(),
-        type: z.intersection(EndpointType, z.enum([ 'webhook', 'email', 'default' ])),
-        updated: Date.optional().nullable()
+        type: z.intersection(
+            zodSchemaEndpointType(),
+            z.enum([ 'webhook', 'email', 'default' ])
+        ),
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaApplication() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
-        eventTypes: SetEventType.optional().nullable(),
-        id: UUID.optional().nullable(),
+        eventTypes: zodSchemaSetEventType().optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
-        updated: Date.optional().nullable()
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaSetEndpoint() {
-    return z.array(Endpoint);
+    return z.array(zodSchemaEndpoint());
 }
 
 export function zodSchemaEventType() {
     return z.object({
         application: z
-        .lazy(() => Application)
+        .lazy(() => zodSchemaApplication())
         .optional()
         .nullable(),
         description: z.string(),
-        endpoints: SetEndpoint.optional().nullable(),
+        endpoints: zodSchemaSetEndpoint().optional().nullable(),
         id: z.number().int().optional().nullable(),
         name: z.string()
     });
 }
 
 export function zodSchemaSetEventType() {
-    return z.array(EventType);
+    return z.array(zodSchemaEventType());
 }
 
 export function zodSchemaNotification() {
     return z.object({
-        endpoint: Endpoint.optional().nullable(),
+        endpoint: zodSchemaEndpoint().optional().nullable(),
         payload: z.unknown().optional().nullable(),
         tenant: z.string().optional().nullable()
     });
@@ -2212,9 +2229,9 @@ export function zodSchemaJsonObject() {
 
 export function zodSchemaNotificationHistory() {
     return z.object({
-        created: Date.optional().nullable(),
-        details: JsonObject.optional().nullable(),
-        endpointId: UUID.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
+        details: zodSchemaJsonObject().optional().nullable(),
+        endpointId: zodSchemaUUID().optional().nullable(),
         id: z.number().int().optional().nullable(),
         invocationResult: z.boolean().optional().nullable(),
         invocationTime: z.number().int().optional().nullable()
@@ -2301,7 +2318,7 @@ export const NotificationHistory = zodSchemaNotificationHistory();
 
 // GET /notifications/defaults
 const NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.array(
-    Endpoint
+    zodSchemaEndpoint()
 );
 export const actionNotificationServiceGetEndpointsForDefaults = () => {
     const path = '/api/notifications/v1.0/notifications/defaults';
@@ -2363,7 +2380,9 @@ const NotificationServiceGetEventTypesParamLimit = z.number().int();
 const NotificationServiceGetEventTypesParamOffset = z.number().int();
 const NotificationServiceGetEventTypesParamPageNumber = z.number().int();
 const NotificationServiceGetEventTypesParamSortBy = z.string();
-const NotificationServiceGetEventTypesParamResponse200 = z.array(EventType);
+const NotificationServiceGetEventTypesParamResponse200 = z.array(
+    zodSchemaEventType()
+);
 /*
  Params
 'limit'?:NotificationServiceGetEventTypesParamLimit,
@@ -2410,7 +2429,9 @@ const NotificationServiceGetLinkedEndpointsParamLimit = z.number().int();
 const NotificationServiceGetLinkedEndpointsParamOffset = z.number().int();
 const NotificationServiceGetLinkedEndpointsParamPageNumber = z.number().int();
 const NotificationServiceGetLinkedEndpointsParamSortBy = z.string();
-const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(Endpoint);
+const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(
+    zodSchemaEndpoint()
+);
 /*
  Params
 'eventTypeId':NotificationServiceGetLinkedEndpointsParamEventTypeId,
@@ -2510,7 +2531,7 @@ export const actionNotificationServiceUnlinkEndpointFromEventType = (
 
 // GET /notifications/updates
 const NotificationServiceGetNotificationUpdatesParamResponse200 = z.array(
-    Notification
+    zodSchemaNotification()
 );
 export const actionNotificationServiceGetNotificationUpdates = () => {
     const path = '/api/notifications/v1.0/notifications/updates';
@@ -2563,7 +2584,7 @@ export function zodSchemaNewCookie() {
         value: z.string().optional().nullable(),
         version: z.number().int().optional().nullable(),
         comment: z.string().optional().nullable(),
-        expiry: Date.optional().nullable(),
+        expiry: zodSchemaDate().optional().nullable(),
         httpOnly: z.boolean().optional().nullable(),
         maxAge: z.number().int().optional().nullable(),
         secure: z.boolean().optional().nullable()
@@ -2571,7 +2592,7 @@ export function zodSchemaNewCookie() {
 }
 
 export function zodSchemaMapStringNewCookie() {
-    return z.record(NewCookie);
+    return z.record(zodSchemaNewCookie());
 }
 
 export function zodSchemaDate() {
@@ -2597,31 +2618,31 @@ export function zodSchemaLocale() {
         displayName: z.string().optional().nullable(),
         displayScript: z.string().optional().nullable(),
         displayVariant: z.string().optional().nullable(),
-        extensionKeys: SetCharacter.optional().nullable(),
+        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
         iSO3Country: z.string().optional().nullable(),
         iSO3Language: z.string().optional().nullable(),
         language: z.string().optional().nullable(),
         script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: SetString.optional().nullable(),
-        unicodeLocaleKeys: SetString.optional().nullable(),
+        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
         variant: z.string().optional().nullable()
     });
 }
 
 export function zodSchemaLink() {
     return z.object({
-        params: MapStringString.optional().nullable(),
+        params: zodSchemaMapStringString().optional().nullable(),
         rel: z.string().optional().nullable(),
-        rels: ListString.optional().nullable(),
+        rels: zodSchemaListString().optional().nullable(),
         title: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
-        uri: URI.optional().nullable(),
-        uriBuilder: UriBuilder.optional().nullable()
+        uri: zodSchemaURI().optional().nullable(),
+        uriBuilder: zodSchemaUriBuilder().optional().nullable()
     });
 }
 
 export function zodSchemaSetLink() {
-    return z.array(Link);
+    return z.array(zodSchemaLink());
 }
 
 export function zodSchemaURI() {
@@ -2630,7 +2651,7 @@ export function zodSchemaURI() {
 
 export function zodSchemaMediaType() {
     return z.object({
-        parameters: MapStringString.optional().nullable(),
+        parameters: zodSchemaMapStringString().optional().nullable(),
         subtype: z.string().optional().nullable(),
         type: z.string().optional().nullable(),
         wildcardSubtype: z.boolean().optional().nullable(),
@@ -2640,7 +2661,7 @@ export function zodSchemaMediaType() {
 
 export function zodSchemaStatusType() {
     return z.object({
-        family: Family.optional().nullable(),
+        family: zodSchemaFamily().optional().nullable(),
         reasonPhrase: z.string().optional().nullable(),
         statusCode: z.number().int().optional().nullable()
     });
@@ -2679,22 +2700,22 @@ export function zodSchemaSetCharacter() {
 
 export function zodSchemaResponse() {
     return z.object({
-        allowedMethods: SetString.optional().nullable(),
-        cookies: MapStringNewCookie.optional().nullable(),
-        date: Date.optional().nullable(),
+        allowedMethods: zodSchemaSetString().optional().nullable(),
+        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+        date: zodSchemaDate().optional().nullable(),
         entity: z.unknown().optional().nullable(),
-        entityTag: EntityTag.optional().nullable(),
-        headers: MultivaluedMapStringObject.optional().nullable(),
-        language: Locale.optional().nullable(),
-        lastModified: Date.optional().nullable(),
+        entityTag: zodSchemaEntityTag().optional().nullable(),
+        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+        language: zodSchemaLocale().optional().nullable(),
+        lastModified: zodSchemaDate().optional().nullable(),
         length: z.number().int().optional().nullable(),
-        links: SetLink.optional().nullable(),
-        location: URI.optional().nullable(),
-        mediaType: MediaType.optional().nullable(),
-        metadata: MultivaluedMapStringObject.optional().nullable(),
+        links: zodSchemaSetLink().optional().nullable(),
+        location: zodSchemaURI().optional().nullable(),
+        mediaType: zodSchemaMediaType().optional().nullable(),
+        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
         status: z.number().int().optional().nullable(),
-        statusInfo: StatusType.optional().nullable(),
-        stringHeaders: MultivaluedMapStringString.optional().nullable()
+        statusInfo: zodSchemaStatusType().optional().nullable(),
+        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
     });
 }
 
@@ -2715,9 +2736,9 @@ export function zodSchemaHttpType() {
 
 export function zodSchemaWebhookAttributes() {
     return z.object({
-        basic_authentication: BasicAuthentication.optional().nullable(),
+        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
         disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(HttpType, z.enum([ 'GET', 'POST', 'PUT' ])),
+        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
         secret_token: z.string().optional().nullable(),
         url: z.string()
     });
@@ -2733,55 +2754,58 @@ export function zodSchemaEndpointType() {
 
 export function zodSchemaEndpoint() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
         enabled: z.boolean().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
         properties: z
-        .union([ WebhookAttributes, EmailAttributes ])
+        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
         .optional()
         .nullable(),
-        type: z.intersection(EndpointType, z.enum([ 'webhook', 'email', 'default' ])),
-        updated: Date.optional().nullable()
+        type: z.intersection(
+            zodSchemaEndpointType(),
+            z.enum([ 'webhook', 'email', 'default' ])
+        ),
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaApplication() {
     return z.object({
-        created: Date.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
         description: z.string(),
-        eventTypes: SetEventType.optional().nullable(),
-        id: UUID.optional().nullable(),
+        eventTypes: zodSchemaSetEventType().optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         name: z.string(),
-        updated: Date.optional().nullable()
+        updated: zodSchemaDate().optional().nullable()
     });
 }
 
 export function zodSchemaSetEndpoint() {
-    return z.array(Endpoint);
+    return z.array(zodSchemaEndpoint());
 }
 
 export function zodSchemaEventType() {
     return z.object({
         application: z
-        .lazy(() => Application)
+        .lazy(() => zodSchemaApplication())
         .optional()
         .nullable(),
         description: z.string(),
-        endpoints: SetEndpoint.optional().nullable(),
+        endpoints: zodSchemaSetEndpoint().optional().nullable(),
         id: z.number().int().optional().nullable(),
         name: z.string()
     });
 }
 
 export function zodSchemaSetEventType() {
-    return z.array(EventType);
+    return z.array(zodSchemaEventType());
 }
 
 export function zodSchemaNotification() {
     return z.object({
-        endpoint: Endpoint.optional().nullable(),
+        endpoint: zodSchemaEndpoint().optional().nullable(),
         payload: z.unknown().optional().nullable(),
         tenant: z.string().optional().nullable()
     });
@@ -2793,9 +2817,9 @@ export function zodSchemaJsonObject() {
 
 export function zodSchemaNotificationHistory() {
     return z.object({
-        created: Date.optional().nullable(),
-        details: JsonObject.optional().nullable(),
-        endpointId: UUID.optional().nullable(),
+        created: zodSchemaDate().optional().nullable(),
+        details: zodSchemaJsonObject().optional().nullable(),
+        endpointId: zodSchemaUUID().optional().nullable(),
         id: z.number().int().optional().nullable(),
         invocationResult: z.boolean().optional().nullable(),
         invocationTime: z.number().int().optional().nullable()
@@ -2965,7 +2989,7 @@ export const actionPostPoliciesIdsEnabled = (
 
 // GET /facts
 // Retrieve a list of fact (keys) along with their data types
-const GetFactsParamResponse200 = z.array(Fact);
+const GetFactsParamResponse200 = z.array(zodSchemaFact());
 type GetFactsParamResponse200 = z.infer<typeof GetFactsParamResponse200>;
 export type GetFactsPayload =
   | ValidatedResponse<'GetFactsParamResponse200', 200, GetFactsParamResponse200>
@@ -3455,7 +3479,7 @@ export const actionGetPoliciesIds = (
 
 // DELETE /policies/ids
 // Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
-const DeletePoliciesIdsParamResponse200 = z.array(UUID);
+const DeletePoliciesIdsParamResponse200 = z.array(zodSchemaUUID());
 type DeletePoliciesIdsParamResponse200 = z.infer<
   typeof DeletePoliciesIdsParamResponse200
 >;
@@ -3683,7 +3707,7 @@ export function zodSchemaPolicy() {
         conditions: z.string(),
         ctime: z.string().optional().nullable(),
         description: z.string().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         isEnabled: z.boolean().optional().nullable(),
         lastTriggered: z.number().int().optional().nullable(),
         mtime: z.string().optional().nullable(),
@@ -3713,15 +3737,15 @@ export function zodSchemaFact() {
     return z.object({
         id: z.number().int().optional().nullable(),
         name: z.string().optional().nullable(),
-        type: FactType.optional().nullable()
+        type: zodSchemaFactType().optional().nullable()
     });
 }
 
 export function zodSchemaPagedResponseOfHistoryItem() {
     return z.object({
-        links: MapStringString.optional().nullable(),
-        meta: Meta.optional().nullable(),
-        data: ListHistoryItem.optional().nullable()
+        links: zodSchemaMapStringString().optional().nullable(),
+        meta: zodSchemaMeta().optional().nullable(),
+        data: zodSchemaListHistoryItem().optional().nullable()
     });
 }
 
@@ -3735,9 +3759,9 @@ export function zodSchemaListUUID() {
 
 export function zodSchemaPagedResponseOfPolicy() {
     return z.object({
-        links: MapStringString.optional().nullable(),
-        meta: Meta.optional().nullable(),
-        data: ListPolicy.optional().nullable()
+        links: zodSchemaMapStringString().optional().nullable(),
+        meta: zodSchemaMeta().optional().nullable(),
+        data: zodSchemaListPolicy().optional().nullable()
     });
 }
 
@@ -3746,7 +3770,7 @@ export function zodSchemaList() {
 }
 
 export function zodSchemaListPolicy() {
-    return z.array(Policy);
+    return z.array(zodSchemaPolicy());
 }
 
 export function zodSchemaUUID() {
@@ -3754,7 +3778,7 @@ export function zodSchemaUUID() {
 }
 
 export function zodSchemaListHistoryItem() {
-    return z.array(HistoryItem);
+    return z.array(zodSchemaHistoryItem());
 }
 
 export function zodSchema__Empty() {
@@ -3871,7 +3895,7 @@ export const actionPostPoliciesIdsEnabled = (params) => {
 
 // GET /facts
 // Retrieve a list of fact (keys) along with their data types
-const GetFactsParamResponse200 = z.array(Fact);
+const GetFactsParamResponse200 = z.array(zodSchemaFact());
 export const actionGetFacts = () => {
     const path = '/api/policies/v1.0/facts';
     const query = {};
@@ -4210,7 +4234,7 @@ export const actionGetPoliciesIds = (params) => {
 
 // DELETE /policies/ids
 // Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
-const DeletePoliciesIdsParamResponse200 = z.array(UUID);
+const DeletePoliciesIdsParamResponse200 = z.array(zodSchemaUUID());
 /*
  Params
 body: ListUUID
@@ -4365,7 +4389,7 @@ export function zodSchemaPolicy() {
         conditions: z.string(),
         ctime: z.string().optional().nullable(),
         description: z.string().optional().nullable(),
-        id: UUID.optional().nullable(),
+        id: zodSchemaUUID().optional().nullable(),
         isEnabled: z.boolean().optional().nullable(),
         lastTriggered: z.number().int().optional().nullable(),
         mtime: z.string().optional().nullable(),
@@ -4395,15 +4419,15 @@ export function zodSchemaFact() {
     return z.object({
         id: z.number().int().optional().nullable(),
         name: z.string().optional().nullable(),
-        type: FactType.optional().nullable()
+        type: zodSchemaFactType().optional().nullable()
     });
 }
 
 export function zodSchemaPagedResponseOfHistoryItem() {
     return z.object({
-        links: MapStringString.optional().nullable(),
-        meta: Meta.optional().nullable(),
-        data: ListHistoryItem.optional().nullable()
+        links: zodSchemaMapStringString().optional().nullable(),
+        meta: zodSchemaMeta().optional().nullable(),
+        data: zodSchemaListHistoryItem().optional().nullable()
     });
 }
 
@@ -4417,9 +4441,9 @@ export function zodSchemaListUUID() {
 
 export function zodSchemaPagedResponseOfPolicy() {
     return z.object({
-        links: MapStringString.optional().nullable(),
-        meta: Meta.optional().nullable(),
-        data: ListPolicy.optional().nullable()
+        links: zodSchemaMapStringString().optional().nullable(),
+        meta: zodSchemaMeta().optional().nullable(),
+        data: zodSchemaListPolicy().optional().nullable()
     });
 }
 
@@ -4428,7 +4452,7 @@ export function zodSchemaList() {
 }
 
 export function zodSchemaListPolicy() {
-    return z.array(Policy);
+    return z.array(zodSchemaPolicy());
 }
 
 export function zodSchemaUUID() {
@@ -4436,7 +4460,7 @@ export function zodSchemaUUID() {
 }
 
 export function zodSchemaListHistoryItem() {
-    return z.array(HistoryItem);
+    return z.array(zodSchemaHistoryItem());
 }
 
 export function zodSchema__Empty() {
@@ -4551,7 +4575,7 @@ export function zodSchemaMessage() {
 }
 
 export function zodSchemaSetFruit() {
-    return z.array(Fruit);
+    return z.array(zodSchemaFruit());
 }
 "
 `;
@@ -4633,7 +4657,7 @@ export function zodSchemaMessage() {
 }
 
 export function zodSchemaSetFruit() {
-    return z.array(Fruit);
+    return z.array(zodSchemaFruit());
 }
 "
 `;


### PR DESCRIPTION
A type could be undefined, but a function is always there. This prevents some errors.