### PR TITLE
Support for filtering with arrays.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   ],
   "scripts": {
     "build": "lerna run build --stream",
+    "start": "lerna run start --stream",
     "ci": "npm-run-all build lint test:ci",
     "lint": "lerna run lint --stream",
     "test": "lerna run test --stream",
@@ -96,6 +97,7 @@
     "rimraf": "3.0.0",
     "rollup": "2.26.10",
     "rollup-plugin-dts": "1.4.12",
+    "rollup-plugin-execute": "1.1.1",
     "stylelint": "11.1.1",
     "stylelint-config-recommended-scss": "4.0.0",
     "stylelint-scss": "3.12.1",

--- a/packages/insights-common-typescript-dev/package.json
+++ b/packages/insights-common-typescript-dev/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
+    "start": "rollup --config --watch --cache",
     "lint": "eslint --ext js,ts,tsx src",
     "lint:fix": "eslint --ext js,ts,tsx src --fix",
     "test": "jest --verbose",

--- a/packages/insights-common-typescript/package.json
+++ b/packages/insights-common-typescript/package.json
@@ -12,6 +12,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
+    "start": "rollup --config --watch --cache",
     "lint": "eslint --ext js,ts,tsx config src",
     "lint:fix": "eslint --ext js,ts,tsx config src --fix",
     "test": "jest --verbose",

--- a/packages/insights-common-typescript/src/hooks/__tests__/useFilters.test.ts
+++ b/packages/insights-common-typescript/src/hooks/__tests__/useFilters.test.ts
@@ -19,14 +19,14 @@ describe('src/hooks/useFilter', () => {
             initialProps: Foo
         });
         expect(result.current.filters).toEqual({
-            A: '',
-            b: '',
-            y: ''
+            A: undefined,
+            b: undefined,
+            y: undefined
         });
         expect(result.current.filters).toEqual({
-            [Foo.A]: '',
-            [Foo.B]: '',
-            [Foo.c]: ''
+            [Foo.A]: undefined,
+            [Foo.B]: undefined,
+            [Foo.c]: undefined
         });
     });
 
@@ -52,14 +52,14 @@ describe('src/hooks/useFilter', () => {
             initialProps: Foo
         });
         expect(result.current.debouncedFilters).toEqual({
-            A: '',
-            b: '',
-            y: ''
+            A: undefined,
+            b: undefined,
+            y: undefined
         });
         expect(result.current.debouncedFilters).toEqual({
-            [Foo.A]: '',
-            [Foo.B]: '',
-            [Foo.c]: ''
+            [Foo.A]: undefined,
+            [Foo.B]: undefined,
+            [Foo.c]: undefined
         });
     });
 
@@ -79,9 +79,9 @@ describe('src/hooks/useFilter', () => {
         });
         expect(result.current.filters.b).toEqual('im b');
         act(() => {
-            result.current.clearFilter([ Foo.B ]);
+            result.current.clearFilter({ [Foo.B]: '' });
         });
-        expect(result.current.filters.b).toEqual('');
+        expect(result.current.filters.b).toEqual(undefined);
     });
 
     it ('clearFilter throws error when sending an unknown column', () => {
@@ -90,7 +90,9 @@ describe('src/hooks/useFilter', () => {
         });
 
         act(() => {
-            expect(() => result.current.clearFilter([ 'moo' as Foo ])).toThrowError('Unexpected column moo');
+            expect(() => result.current.clearFilter({
+                ['moo' as Foo]: ''
+            })).toThrowError('Unexpected column moo');
         });
     });
 
@@ -102,14 +104,14 @@ describe('src/hooks/useFilter', () => {
         rerender(Foo);
 
         expect(result.current.debouncedFilters).toEqual({
-            A: '',
-            b: '',
-            y: ''
+            A: undefined,
+            b: undefined,
+            y: undefined
         });
         expect(result.current.debouncedFilters).toEqual({
-            [Foo.A]: '',
-            [Foo.B]: '',
-            [Foo.c]: ''
+            [Foo.A]: undefined,
+            [Foo.B]: undefined,
+            [Foo.c]: undefined
         });
     });
 
@@ -157,7 +159,7 @@ describe('src/hooks/useFilter', () => {
         expect(result.current.filters.A).toEqual('foobar');
     });
 
-    it ('debouncedFilter changes when calling a setter after the debounce delay', () => {
+    it('debouncedFilter changes when calling a setter after the debounce delay', () => {
         jest.useFakeTimers();
         const { result } = renderHook((Enum) => useFilters(Enum, 500), {
             initialProps: Foo
@@ -168,13 +170,13 @@ describe('src/hooks/useFilter', () => {
             // eslint-disable-next-line new-cap
             result.current.setFilters.A('foobar');
         });
-        expect(result.current.debouncedFilters.A).toBe('');
+        expect(result.current.debouncedFilters.A).toBe(undefined);
         expect(prev).toBe(result.current.debouncedFilters);
 
         act(() => {
             jest.advanceTimersByTime(300);
         });
-        expect(result.current.debouncedFilters.A).toBe('');
+        expect(result.current.debouncedFilters.A).toBe(undefined);
         expect(prev).toBe(result.current.debouncedFilters);
 
         act(() => {
@@ -215,14 +217,14 @@ describe('src/hooks/useFilter', () => {
         });
 
         expect(result.current.filters).toEqual({
-            A: '',
-            b: '',
-            y: ''
+            A: undefined,
+            b: undefined,
+            y: undefined
         });
         expect(result.current.filters).toEqual({
-            [Foo.A]: '',
-            [Foo.B]: '',
-            [Foo.c]: ''
+            [Foo.A]: undefined,
+            [Foo.B]: undefined,
+            [Foo.c]: undefined
         });
 
         expect(Object.keys(result.current.setFilters)).toEqual([
@@ -232,14 +234,14 @@ describe('src/hooks/useFilter', () => {
         rerender(Bar);
 
         expect(result.current.filters).toEqual({
-            A: '',
-            b: '',
-            y: ''
+            A: undefined,
+            b: undefined,
+            y: undefined
         });
         expect(result.current.filters).toEqual({
-            [Foo.A]: '',
-            [Foo.B]: '',
-            [Foo.c]: ''
+            [Foo.A]: undefined,
+            [Foo.B]: undefined,
+            [Foo.c]: undefined
         });
 
         expect(Object.keys(result.current.setFilters)).toEqual([

--- a/packages/insights-common-typescript/src/hooks/__tests__/usePrimaryToolbarFilterConfig.test.ts
+++ b/packages/insights-common-typescript/src/hooks/__tests__/usePrimaryToolbarFilterConfig.test.ts
@@ -53,7 +53,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-a`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.A',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -64,7 +64,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -75,7 +75,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -86,7 +86,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -146,7 +146,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -157,7 +157,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -168,7 +168,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -178,7 +178,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
         }));
     });
 
-    it('Filter config with exclusive options throws error', () => {
+    it('Filter config with exclusive false works', () => {
         const { result } = renderHook(() => {
             const { filters, setFilters, clearFilter } = useFilters(Foo);
             return usePrimaryToolbarFilterConfig(
@@ -200,7 +200,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
             );
         });
 
-        expect(() => result.current.filterConfig).toThrowError();
+        expect(() => result.current.filterConfig).not.toThrowError();
     });
 
     it('Filter config only sets options', () => {
@@ -260,7 +260,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -271,7 +271,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -282,7 +282,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -323,7 +323,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -334,7 +334,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -345,7 +345,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -413,7 +413,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -424,7 +424,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -435,7 +435,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -497,7 +497,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -508,7 +508,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -519,7 +519,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -583,7 +583,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -594,7 +594,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -605,7 +605,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -636,7 +636,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-a`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.A',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -647,7 +647,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-b`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.B',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -658,7 +658,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -669,7 +669,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -703,7 +703,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-a`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.A',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -725,7 +725,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -736,7 +736,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -770,7 +770,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-a`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.A',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -792,7 +792,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-c`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'I find your lack of foo disturbing',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -803,7 +803,7 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
                     type: 'text',
                     filterValues: {
                         id: `filter-x`,
-                        value: '',
+                        value: undefined,
                         placeholder: 'Im Foo.Z',
                         // eslint-disable-next-line @typescript-eslint/no-empty-function
                         onChange() {}
@@ -886,7 +886,14 @@ describe('src/hooks/usePrimaryToolbarFilterConfig', () => {
             result.current.activeFiltersConfig.onDelete(
                 undefined,
                 [
-                    { category: 'Foo.A' }
+                    {
+                        category: 'Foo.A',
+                        chips: [
+                            {
+                                name: 'Foo'
+                            }
+                        ]
+                    }
                 ]);
         });
 

--- a/packages/insights-common-typescript/src/hooks/__tests__/useUrlStateMultipleOptions.test.tsx
+++ b/packages/insights-common-typescript/src/hooks/__tests__/useUrlStateMultipleOptions.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import { useUrlStateExclusiveOptions } from '../..';
+import { useUrlStateMultipleOptions } from '../..';
 import * as React from 'react';
 import { MemoryRouter, useLocation, useHistory } from 'react-router';
 import { waitForAsyncEventsHooks } from '../../../test/TestUtils';
@@ -15,21 +15,35 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
     it('Uses the default value', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
             wrapper: getWrapper()
         });
 
-        expect(result.current.state[0]).toEqual('foo');
+        expect(result.current.state[0]).toEqual([ 'foo' ]);
         expect(result.current.location.search).toEqual('?varname=foo');
+    });
+
+    it('Uses the default value with multiple options', () => {
+        const { result } = renderHook(() => {
+            return {
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo', 'bar' ]),
+                location: useLocation()
+            };
+        }, {
+            wrapper: getWrapper()
+        });
+
+        expect(result.current.state[0]).toEqual([ 'foo', 'bar' ]);
+        expect(result.current.location.search).toEqual('?varname=foo%2Cbar');
     });
 
     it('Sets value', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
@@ -37,59 +51,73 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
         });
 
         act(() => {
-            result.current.state[1]('baz');
+            result.current.state[1]([ 'baz' ]);
         });
 
-        expect(result.current.state[0]).toEqual('baz');
+        expect(result.current.state[0]).toEqual([ 'baz' ]);
         expect(result.current.location.search).toEqual('?varname=baz');
     });
 
     it('Loads from url', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
             wrapper: getWrapper('?varname=bar')
         });
 
-        expect(result.current.state[0]).toEqual('bar');
+        expect(result.current.state[0]).toEqual([ 'bar' ]);
         expect(result.current.location.search).toEqual('?varname=bar');
     });
 
-    it('Loading from url uses undefined if value is not any option', () => {
+    it('Loads multiple values from url', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
+                location: useLocation()
+            };
+        }, {
+            wrapper: getWrapper('?varname=bar%2Cbaz')
+        });
+
+        expect(result.current.state[0]).toEqual([ 'bar', 'baz' ]);
+        expect(result.current.location.search).toEqual('?varname=bar%2Cbaz');
+    });
+
+    it('Loading from url uses [] if value is not any option', () => {
+        const { result } = renderHook(() => {
+            return {
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
             wrapper: getWrapper('?varname=captain')
         });
 
-        expect(result.current.state[0]).toEqual(undefined);
+        expect(result.current.state[0]).toEqual([]);
         expect(result.current.location.search).toEqual('?');
     });
 
     it('Ignores case when watching, but preserves case option', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'BAR', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'BAR', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
             wrapper: getWrapper('?varname=BaR')
         });
 
-        expect(result.current.state[0]).toEqual('BAR');
+        expect(result.current.state[0]).toEqual([ 'BAR' ]);
         expect(result.current.location.search).toEqual('?varname=BAR');
     });
 
     it('Loads from url when it changes (and still only accepts initialOptions)', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation(),
                 history: useHistory()
             };
@@ -103,14 +131,14 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
             });
         });
 
-        expect(result.current.state[0]).toEqual('baz');
+        expect(result.current.state[0]).toEqual([ 'baz' ]);
         expect(result.current.location.search).toEqual('?varname=baz');
     });
 
     it('Works if the url is unset', () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation(),
                 history: useHistory()
             };
@@ -122,14 +150,14 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
             result.current.history.replace({});
         });
 
-        expect(result.current.state[0]).toEqual(undefined);
+        expect(result.current.state[0]).toEqual([]);
         expect(result.current.location.search).toEqual('');
     });
 
-    it('Values not in the options are undefined', async () => {
+    it('Values not in the options are []', async () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', [ 'foo', 'bar', 'baz' ], 'foo'),
+                state: useUrlStateMultipleOptions('varname', [ 'foo', 'bar', 'baz' ], [ 'foo' ]),
                 location: useLocation()
             };
         }, {
@@ -138,14 +166,14 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
 
         await waitForAsyncEventsHooks();
 
-        expect(result.current.state[0]).toEqual(undefined);
+        expect(result.current.state[0]).toEqual([]);
         expect(result.current.location.search).toEqual('?');
     });
 
     it('If options are undefined, uses what is received', async () => {
         const { result } = renderHook(() => {
             return {
-                state: useUrlStateExclusiveOptions('varname', undefined),
+                state: useUrlStateMultipleOptions('varname', undefined),
                 location: useLocation()
             };
         }, {
@@ -154,7 +182,7 @@ describe('src/hooks/useUrlStateExclusiveOptions', () => {
 
         await waitForAsyncEventsHooks();
 
-        expect(result.current.state[0]).toEqual('bOx');
+        expect(result.current.state[0]).toEqual([ 'bOx' ]);
         expect(result.current.location.search).toEqual('?varname=bOx');
     });
 });

--- a/packages/insights-common-typescript/src/hooks/index.ts
+++ b/packages/insights-common-typescript/src/hooks/index.ts
@@ -6,3 +6,4 @@ export * from './useSort';
 export * from './useSyncInterval';
 export * from './useUrlState';
 export * from './useUrlStateExclusiveOptions';
+export * from './useUrlStateMultipleOptions';

--- a/packages/insights-common-typescript/src/hooks/useSort.ts
+++ b/packages/insights-common-typescript/src/hooks/useSort.ts
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { Direction, OnSortHandlerType, Sort } from '../types/Page';
+import { Direction, OnSortHandlerType, Sort } from '../types';
 
-export interface UsePolicySortReturn {
+export interface UseSortReturn {
     sortBy: Sort | undefined;
     onSort: OnSortHandlerType;
 }
 
-export const useSort = (defaultSort?: Sort): UsePolicySortReturn => {
+export const useSort = (defaultSort?: Sort): UseSortReturn => {
 
     const [ sortBy, setSortBy ] = React.useState<Sort | undefined>(defaultSort);
 

--- a/packages/insights-common-typescript/src/hooks/useUrlStateExclusiveOptions.ts
+++ b/packages/insights-common-typescript/src/hooks/useUrlStateExclusiveOptions.ts
@@ -1,18 +1,21 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useUrlState } from './useUrlState';
 
 type Unpacked<T> = T extends (infer U)[]  ? U : T;
 
-export const useUrlStateExclusiveOptions = <T extends string, AT extends Array<T>>(name: string, initialOptions: AT, defaultValue?: Unpacked<AT>) => {
-    const [ options ] = useState(initialOptions);
-    const lowerCaseOptions = useMemo(() => options.map(o => o.trim().toLowerCase()), [ options ]);
+export const useUrlStateExclusiveOptions = <T extends string, AT extends Array<T>>(name: string, options?: AT, defaultValue?: Unpacked<AT>) => {
+    const lowerCaseOptions = useMemo(() => options?.map(o => o.trim().toLowerCase()), [ options ]);
 
     const serializer = useCallback((val: Unpacked<AT> | undefined) => {
         const value = val?.trim().toLowerCase();
         if (value) {
-            const index = lowerCaseOptions.indexOf(value);
-            if (index !== -1) {
-                return options[index];
+            if (lowerCaseOptions && options) {
+                const index = lowerCaseOptions.indexOf(value);
+                if (index !== -1) {
+                    return options[index];
+                }
+            } else {
+                return val;
             }
         }
 
@@ -20,11 +23,15 @@ export const useUrlStateExclusiveOptions = <T extends string, AT extends Array<T
     }, [ lowerCaseOptions, options ]);
 
     const deserializer = useCallback((val: string | undefined) => {
-        const value = val?.trim().toLowerCase();
+        const value = val?.trim();
         if (value) {
-            const index = lowerCaseOptions.indexOf(value);
-            if (index !== -1) {
-                return options[index] as Unpacked<AT>;
+            if (options && lowerCaseOptions) {
+                const index = lowerCaseOptions.indexOf(value.toLowerCase());
+                if (index !== -1) {
+                    return options[index] as Unpacked<AT>;
+                }
+            } else {
+                return value as Unpacked<AT>;
             }
         }
 

--- a/packages/insights-common-typescript/src/hooks/useUrlStateMultipleOptions.ts
+++ b/packages/insights-common-typescript/src/hooks/useUrlStateMultipleOptions.ts
@@ -1,0 +1,38 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useUrlState } from './useUrlState';
+
+export const useUrlStateMultipleOptions = <T extends string>(name: string, initialOptions: Array<T>, defaultValue?: Array<T>) => {
+    const [ options ] = useState(initialOptions);
+    const lowerCaseOptions = useMemo(() => options.map(o => o.trim().toLowerCase()), [ options ]);
+
+    const serializer = useCallback((val: Array<T> | undefined) => {
+        const value = val?.map(v => v.toLowerCase());
+        if (value) {
+            return value.map(v => lowerCaseOptions.indexOf(v))
+            .filter(i => i !== -1)
+            .map(i => options[i])
+            .join(',');
+        }
+
+        return undefined;
+    }, [ lowerCaseOptions, options ]);
+
+    const deserializer = useCallback((val: string | undefined) => {
+        const value = val?.trim().toLowerCase().split(',');
+        if (value) {
+            return value
+            .map(v => lowerCaseOptions.indexOf(v))
+            .filter(i => i !== -1)
+            .map(i => options[i]);
+        }
+
+        return [];
+    }, [ lowerCaseOptions, options ]);
+
+    return useUrlState<Array<T>>(
+        name,
+        serializer,
+        deserializer,
+        defaultValue
+    );
+};

--- a/packages/insights-common-typescript/src/hooks/useUrlStateMultipleOptions.ts
+++ b/packages/insights-common-typescript/src/hooks/useUrlStateMultipleOptions.ts
@@ -1,29 +1,40 @@
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 import { useUrlState } from './useUrlState';
 
-export const useUrlStateMultipleOptions = <T extends string>(name: string, initialOptions: Array<T>, defaultValue?: Array<T>) => {
-    const [ options ] = useState(initialOptions);
-    const lowerCaseOptions = useMemo(() => options.map(o => o.trim().toLowerCase()), [ options ]);
+export const useUrlStateMultipleOptions = <T extends string>(name: string, options?: Array<T>, defaultValue?: Array<T>) => {
+    const lowerCaseOptions = useMemo(() => options?.map(o => o.trim().toLowerCase()), [ options ]);
 
     const serializer = useCallback((val: Array<T> | undefined) => {
         const value = val?.map(v => v.toLowerCase());
         if (value) {
-            return value.map(v => lowerCaseOptions.indexOf(v))
-            .filter(i => i !== -1)
-            .map(i => options[i])
-            .join(',');
+            if (lowerCaseOptions && options) {
+                const result = value.map(v => lowerCaseOptions.indexOf(v))
+                .filter(i => i !== -1)
+                .map(i => options[i]);
+                if (result.length > 0) {
+                    return result.join(',');
+                }
+            } else {
+                if (val && val.length > 0) {
+                    return val.join(',');
+                }
+            }
         }
 
         return undefined;
     }, [ lowerCaseOptions, options ]);
 
     const deserializer = useCallback((val: string | undefined) => {
-        const value = val?.trim().toLowerCase().split(',');
+        const value = val?.trim().split(',');
         if (value) {
-            return value
-            .map(v => lowerCaseOptions.indexOf(v))
-            .filter(i => i !== -1)
-            .map(i => options[i]);
+            if (lowerCaseOptions && options) {
+                return value
+                .map(v => lowerCaseOptions.indexOf(v.toLowerCase()))
+                .filter(i => i !== -1)
+                .map(i => options[i]);
+            } else {
+                return val ? value as Array<T> : [];
+            }
         }
 
         return [];

--- a/packages/insights-common-typescript/src/types/Filters.ts
+++ b/packages/insights-common-typescript/src/types/Filters.ts
@@ -1,8 +1,14 @@
-type Setter<T> = (val: T) => void;
+type Setter<T> = (val: T | ((prev: T) => T)) => void;
 
 export type StandardFilterEnum<T> = Record<keyof T, string>;
+export type FilterContent = string | Array<string> | undefined;
+
 export type EnumElement<Enum> = Enum[keyof Enum];
+
 export type FilterBase<Enum extends StandardFilterEnum<any>, T> = Record<EnumElement<Enum>, T>;
-export type Filters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, string>;
-export type SetFilters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, Setter<string>>;
-export type ClearFilters<Enum> = (columns: Array<EnumElement<Enum>>) => void;
+export type Filters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, FilterContent>;
+export type SetFilters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, Setter<FilterContent>>;
+export type ClearFilterElement<Enum extends StandardFilterEnum<any>> = {
+    [P in EnumElement<Enum>]?: FilterContent;
+};
+export type ClearFilters<Enum extends StandardFilterEnum<any>> = (columns: ClearFilterElement<Enum>) => void;

--- a/packages/insights-common-typescript/src/types/Filters.ts
+++ b/packages/insights-common-typescript/src/types/Filters.ts
@@ -12,3 +12,27 @@ export type ClearFilterElement<Enum extends StandardFilterEnum<any>> = {
     [P in EnumElement<Enum>]?: FilterContent;
 };
 export type ClearFilters<Enum extends StandardFilterEnum<any>> = (columns: ClearFilterElement<Enum>) => void;
+
+export const stringValue = (val: string | Array<string> | undefined, separator = ','): string => {
+    if (val) {
+        if (typeof val === 'string') {
+            return val;
+        }
+
+        return val.join(separator);
+    }
+
+    return '';
+};
+
+export const arrayValue = (val: string | Array<string> | undefined, separator = ','): Array<string> => {
+    if (val) {
+        if (typeof val === 'string') {
+            return val.split(separator);
+        }
+
+        return val;
+    }
+
+    return [];
+};

--- a/packages/insights-common-typescript/src/types/Page.ts
+++ b/packages/insights-common-typescript/src/types/Page.ts
@@ -43,8 +43,8 @@ export class Page {
         return Page.of(this.index, this.size, this.filter, sort);
     }
 
-    public toQuery(): Record<string, string> {
-        const queryParams = {} as Record<string, string>;
+    public toQuery(): Record<string, string | ReadonlyArray<string>> {
+        const queryParams = {} as Record<string, string | ReadonlyArray<string>>;
 
         if (this.size === Page.NO_SIZE) {
             queryParams.offset = this.index.toString();
@@ -85,9 +85,9 @@ export class Page {
 class FilterElement {
     readonly column: string;
     readonly operator: Operator;
-    readonly value: string;
+    readonly value: string | Array<string>;
 
-    public constructor(column: string, operator: Operator, value: string) {
+    public constructor(column: string, operator: Operator, value: string | Array<string>) {
         this.column = column;
         this.operator = operator;
         this.value = value;
@@ -102,7 +102,7 @@ export class Filter {
         this.elements = this._elements = [];
     }
 
-    public and(column: string, operator: Operator, value: string) {
+    public and(column: string, operator: Operator, value: string | Array<string>) {
         this._elements.push(new FilterElement(column, operator, value));
         return this;
     }

--- a/packages/openapi2typescript-cli/package.json
+++ b/packages/openapi2typescript-cli/package.json
@@ -11,6 +11,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
+    "start": "rollup --config --watch --cache",
     "lint": "eslint --ext js,ts,tsx src",
     "lint:fix": "eslint --ext js,ts,tsx src --fix",
     "test": "jest --verbose",

--- a/packages/openapi2typescript-cli/rollup.config.js
+++ b/packages/openapi2typescript-cli/rollup.config.js
@@ -2,49 +2,56 @@ import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import typescript from '@rollup/plugin-typescript';
+import execute from 'rollup-plugin-execute';
 
-const extensions = [ '.js', '.ts' ];
+export default function makeConfig(params) {
+    const extensions = [ '.js', '.ts' ];
 
-const config = [
-    {
-        input: 'src/main.ts',
-        output: [
-            {
-                file: 'lib/main.js',
-                format: 'cjs',
-                banner: '#!/usr/bin/env node'
-            }
-        ],
-        external: [
-            'fs', 'child_process', 'path', 'readline', 'os', 'events', 'util'
-        ],
-        plugins: [
-            json(),
-            typescript({
-                sourceMap: false,
-                declaration: false,
-                allowSyntheticDefaultImports: true,
-                include: 'src/**/*'
-            }),
-            resolve({
-                resolveOnly: [
-                    'node-fetch',
-                    'is-url',
-                    'commander',
-                    'camelcase',
-                    'assert-never'
-                ],
-                extensions,
-                preferBuiltins: false
-            }),
-            commonjs({
-                extensions,
-                ignore: [
-                    'camelcase'
-                ]
-            })
-        ]
+    const plugins = [
+        json(),
+        typescript({
+            sourceMap: false,
+            declaration: false,
+            allowSyntheticDefaultImports: true,
+            include: 'src/**/*'
+        }),
+        resolve({
+            resolveOnly: [
+                'node-fetch',
+                'is-url',
+                'commander',
+                'camelcase',
+                'assert-never'
+            ],
+            extensions,
+            preferBuiltins: false
+        }),
+        commonjs({
+            extensions,
+            ignore: [
+                'camelcase'
+            ]
+        })
+    ];
+
+    if (params.watch) {
+        plugins.push(execute('which yalc > /dev/null && yalc publish --changed --push'));
     }
-];
 
-export default config;
+    return [
+        {
+            input: 'src/main.ts',
+            output: [
+                {
+                    file: 'lib/main.js',
+                    format: 'cjs',
+                    banner: '#!/usr/bin/env node'
+                }
+            ],
+            external: [
+                'fs', 'child_process', 'path', 'readline', 'os', 'events', 'util'
+            ],
+            plugins
+        }
+    ];
+}

--- a/packages/openapi2typescript-cli/src/core/ApiBase.ts
+++ b/packages/openapi2typescript-cli/src/core/ApiBase.ts
@@ -16,6 +16,8 @@ export interface Options {
     skipTypes: boolean;
     strict: boolean;
     explicitTypes: boolean;
+    useFunctionTypeGenerator: boolean;
+    schemasPrefix: string;
 }
 
 export class ApiBase {
@@ -31,6 +33,8 @@ export class ApiBase {
             skipTypes: false,
             strict: true,
             explicitTypes: false,
+            useFunctionTypeGenerator: true,
+            schemasPrefix: '',
             ...options
         };
         this.localBuffer = [];
@@ -86,7 +90,7 @@ export class ApiBase {
 
     protected schemaTypes(schema: SchemaOrType, doNotUseModifiers?: boolean) {
         if (isType(schema)) {
-            this.appendTemp(schema.typeName);
+            this.appendTemp(this.fullTypeName(schema));
         } else {
             switch (schema.type) {
                 case SchemaType.ALL_OF:
@@ -253,7 +257,11 @@ export class ApiBase {
             }
 
             // This allows to use an schema that hasn't been defined yet
-            this.appendTemp(`${this.functionName(schema)}()`);
+            if (this.options.useFunctionTypeGenerator) {
+                this.appendTemp(`${this.functionName(schema)}()`);
+            } else {
+                this.appendTemp(this.fullTypeName(schema));
+            }
 
             if (schema.hasLoop) {
                 this.appendTemp(')');
@@ -371,6 +379,10 @@ export class ApiBase {
 
     protected functionName(type: Type<Schema> | SchemaWithTypeName) {
         return `zodSchema${type.typeName}`;
+    }
+
+    protected  fullTypeName(schema: Type<Schema>) {
+        return `${this.options.schemasPrefix}${schema.typeName}`;
     }
 
     protected isUnknown(schemaOrType: SchemaOrType): boolean {

--- a/packages/openapi2typescript-cli/src/core/types/Buffer.ts
+++ b/packages/openapi2typescript-cli/src/core/types/Buffer.ts
@@ -1,8 +1,7 @@
 export enum BufferType {
     HEADER,
-    TYPES,
+    COMPONENTS,
     OPERATIONS,
-    FUNCTIONS,
     FOOTER
 }
 

--- a/packages/openapi2typescript-cli/src/react-fetching-library/ApiActionBuilder.ts
+++ b/packages/openapi2typescript-cli/src/react-fetching-library/ApiActionBuilder.ts
@@ -20,18 +20,18 @@ export class ReactFetchingLibraryApiActionBuilder extends ApiActionBuilder {
     }
 
     protected buildActionFunction(operation: Operation) {
-        const actionType = this.actionEndpointType(operation.id);
-        const payloadType = this.payloadEndpointType(operation.id);
+        const actionType = this.actionEndpointType();
+        const payloadType = this.payloadEndpointType();
 
         if (!this.options.skipTypes) {
             this.appendTemp(`export type ${actionType} = Action<${payloadType}, ActionValidatableConfig>;\n`);
         }
 
-        this.appendTemp(`export const ${this.functionEndpointType(operation.id)} = (`);
+        this.appendTemp(`export const ${this.functionEndpointType()} = (`);
         if ((operation.parameters && operation.parameters.length > 0) || operation.requestBody) {
             this.appendTemp('params');
             if (!this.options.skipTypes) {
-                this.appendTemp(`: ${operation.id}`);
+                this.appendTemp(': Params');
             }
         }
 
@@ -64,7 +64,7 @@ export class ReactFetchingLibraryApiActionBuilder extends ApiActionBuilder {
         if (operation.parameters) {
             this.filteredParameters(operation.parameters).filter(p => p.type === ParamType.QUERY).forEach(param => {
                 this.appendTemp(`if (params['${this.paramName(param.name)}'] !== undefined) {\n`);
-                this.appendTemp(`query['${param.name}'] = params['${this.paramName(param.name)}'].toString();\n`);
+                this.appendTemp(`query['${param.name}'] = params['${this.paramName(param.name)}'];\n`);
                 this.appendTemp('}\n\n');
             });
         }
@@ -80,8 +80,9 @@ export class ReactFetchingLibraryApiActionBuilder extends ApiActionBuilder {
             this.appendTemp('.config({\nrules:[\n');
             const responses = Object.values(operation.responses);
             responses.forEach((response, index, array) => {
-                const responseType = this.responseTypeName(operation.id, response);
-                this.appendTemp(`new ValidateRule(${responseType}, '${responseType}', ${response.status})\n`);
+                const responseType = this.responseTypeName(response, false);
+                const responseTypeName = this.responseTypeName(response, true);
+                this.appendTemp(`new ValidateRule(${responseTypeName}, '${responseType}', ${response.status})\n`);
                 if (array.length !== index + 1) {
                     this.appendTemp(',\n');
                 }

--- a/packages/openapi2typescript-cli/tests/__snapshots__/main.test.ts.snap
+++ b/packages/openapi2typescript-cli/tests/__snapshots__/main.test.ts.snap
@@ -14,825 +14,685 @@ import {
     ActionValidatableConfig
 } from 'openapi2typescript/react-fetching-library';
 
-export const UUID = zodSchemaUUID();
-export type UUID = z.infer<typeof UUID>;
+export namespace Schemas {
+  export const UUID = zodSchemaUUID();
+  export type UUID = z.infer<typeof UUID>;
 
-export const SetString = zodSchemaSetString();
-export type SetString = z.infer<typeof SetString>;
+  export const SetString = zodSchemaSetString();
+  export type SetString = z.infer<typeof SetString>;
 
-export const NewCookie = zodSchemaNewCookie();
-export type NewCookie = z.infer<typeof NewCookie>;
+  export const NewCookie = zodSchemaNewCookie();
+  export type NewCookie = z.infer<typeof NewCookie>;
 
-export const MapStringNewCookie = zodSchemaMapStringNewCookie();
-export type MapStringNewCookie = z.infer<typeof MapStringNewCookie>;
+  export const MapStringNewCookie = zodSchemaMapStringNewCookie();
+  export type MapStringNewCookie = z.infer<typeof MapStringNewCookie>;
 
-export const Date = zodSchemaDate();
-export type Date = z.infer<typeof Date>;
+  export const Date = zodSchemaDate();
+  export type Date = z.infer<typeof Date>;
 
-export const EntityTag = zodSchemaEntityTag();
-export type EntityTag = z.infer<typeof EntityTag>;
+  export const EntityTag = zodSchemaEntityTag();
+  export type EntityTag = z.infer<typeof EntityTag>;
 
-export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
-export type MultivaluedMapStringObject = z.infer<
-  typeof MultivaluedMapStringObject
->;
+  export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
+  export type MultivaluedMapStringObject = z.infer<
+    typeof MultivaluedMapStringObject
+  >;
 
-export const Locale = zodSchemaLocale();
-export type Locale = z.infer<typeof Locale>;
+  export const Locale = zodSchemaLocale();
+  export type Locale = z.infer<typeof Locale>;
 
-export const Link = zodSchemaLink();
-export type Link = z.infer<typeof Link>;
+  export const Link = zodSchemaLink();
+  export type Link = z.infer<typeof Link>;
 
-export const SetLink = zodSchemaSetLink();
-export type SetLink = z.infer<typeof SetLink>;
+  export const SetLink = zodSchemaSetLink();
+  export type SetLink = z.infer<typeof SetLink>;
 
-export const URI = zodSchemaURI();
-export type URI = z.infer<typeof URI>;
+  export const URI = zodSchemaURI();
+  export type URI = z.infer<typeof URI>;
 
-export const MediaType = zodSchemaMediaType();
-export type MediaType = z.infer<typeof MediaType>;
+  export const MediaType = zodSchemaMediaType();
+  export type MediaType = z.infer<typeof MediaType>;
 
-export const StatusType = zodSchemaStatusType();
-export type StatusType = z.infer<typeof StatusType>;
+  export const StatusType = zodSchemaStatusType();
+  export type StatusType = z.infer<typeof StatusType>;
 
-export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
-export type MultivaluedMapStringString = z.infer<
-  typeof MultivaluedMapStringString
->;
+  export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
+  export type MultivaluedMapStringString = z.infer<
+    typeof MultivaluedMapStringString
+  >;
 
-export const Family = zodSchemaFamily();
-export type Family = z.infer<typeof Family>;
+  export const Family = zodSchemaFamily();
+  export type Family = z.infer<typeof Family>;
 
-export const MapStringString = zodSchemaMapStringString();
-export type MapStringString = z.infer<typeof MapStringString>;
+  export const MapStringString = zodSchemaMapStringString();
+  export type MapStringString = z.infer<typeof MapStringString>;
 
-export const ListString = zodSchemaListString();
-export type ListString = z.infer<typeof ListString>;
+  export const ListString = zodSchemaListString();
+  export type ListString = z.infer<typeof ListString>;
 
-export const UriBuilder = zodSchemaUriBuilder();
-export type UriBuilder = z.infer<typeof UriBuilder>;
+  export const UriBuilder = zodSchemaUriBuilder();
+  export type UriBuilder = z.infer<typeof UriBuilder>;
 
-export const SetCharacter = zodSchemaSetCharacter();
-export type SetCharacter = z.infer<typeof SetCharacter>;
+  export const SetCharacter = zodSchemaSetCharacter();
+  export type SetCharacter = z.infer<typeof SetCharacter>;
 
-export const Response = zodSchemaResponse();
-export type Response = z.infer<typeof Response>;
+  export const Response = zodSchemaResponse();
+  export type Response = z.infer<typeof Response>;
 
-export const Attributes = zodSchemaAttributes();
-export type Attributes = z.infer<typeof Attributes>;
+  export const Attributes = zodSchemaAttributes();
+  export type Attributes = z.infer<typeof Attributes>;
 
-export const BasicAuthentication = zodSchemaBasicAuthentication();
-export type BasicAuthentication = z.infer<typeof BasicAuthentication>;
+  export const BasicAuthentication = zodSchemaBasicAuthentication();
+  export type BasicAuthentication = z.infer<typeof BasicAuthentication>;
 
-export const HttpType = zodSchemaHttpType();
-export type HttpType = z.infer<typeof HttpType>;
+  export const HttpType = zodSchemaHttpType();
+  export type HttpType = z.infer<typeof HttpType>;
 
-export const WebhookAttributes = zodSchemaWebhookAttributes();
-export type WebhookAttributes = z.infer<typeof WebhookAttributes>;
+  export const WebhookAttributes = zodSchemaWebhookAttributes();
+  export type WebhookAttributes = z.infer<typeof WebhookAttributes>;
 
-export const EmailAttributes = zodSchemaEmailAttributes();
-export type EmailAttributes = z.infer<typeof EmailAttributes>;
+  export const EmailAttributes = zodSchemaEmailAttributes();
+  export type EmailAttributes = z.infer<typeof EmailAttributes>;
 
-export const EndpointType = zodSchemaEndpointType();
-export type EndpointType = z.infer<typeof EndpointType>;
+  export const EndpointType = zodSchemaEndpointType();
+  export type EndpointType = z.infer<typeof EndpointType>;
 
-export const Endpoint = zodSchemaEndpoint();
-export type Endpoint = z.infer<typeof Endpoint>;
+  export const Endpoint = zodSchemaEndpoint();
+  export type Endpoint = z.infer<typeof Endpoint>;
 
-export const Application = zodSchemaApplication();
-export type Application = z.infer<typeof Application>;
+  export const Application = zodSchemaApplication();
+  export type Application = z.infer<typeof Application>;
 
-export const SetEndpoint = zodSchemaSetEndpoint();
-export type SetEndpoint = z.infer<typeof SetEndpoint>;
+  export const SetEndpoint = zodSchemaSetEndpoint();
+  export type SetEndpoint = z.infer<typeof SetEndpoint>;
 
-export const EventType = zodSchemaEventType();
-export type EventType = z.infer<typeof EventType>;
+  export const EventType = zodSchemaEventType();
+  export type EventType = z.infer<typeof EventType>;
 
-export const SetEventType = zodSchemaSetEventType();
-export type SetEventType = z.infer<typeof SetEventType>;
+  export const SetEventType = zodSchemaSetEventType();
+  export type SetEventType = z.infer<typeof SetEventType>;
 
-export const Notification = zodSchemaNotification();
-export type Notification = z.infer<typeof Notification>;
+  export const Notification = zodSchemaNotification();
+  export type Notification = z.infer<typeof Notification>;
 
-export const JsonObject = zodSchemaJsonObject();
-export type JsonObject = z.infer<typeof JsonObject>;
+  export const JsonObject = zodSchemaJsonObject();
+  export type JsonObject = z.infer<typeof JsonObject>;
 
-export const NotificationHistory = zodSchemaNotificationHistory();
-export type NotificationHistory = z.infer<typeof NotificationHistory>;
+  export const NotificationHistory = zodSchemaNotificationHistory();
+  export type NotificationHistory = z.infer<typeof NotificationHistory>;
 
-// GET /endpoints
-const EndpointServiceGetEndpointsParamActive = z.boolean();
-type EndpointServiceGetEndpointsParamActive = z.infer<
-  typeof EndpointServiceGetEndpointsParamActive
->;
-const EndpointServiceGetEndpointsParamLimit = z.number().int();
-type EndpointServiceGetEndpointsParamLimit = z.infer<
-  typeof EndpointServiceGetEndpointsParamLimit
->;
-const EndpointServiceGetEndpointsParamOffset = z.number().int();
-type EndpointServiceGetEndpointsParamOffset = z.infer<
-  typeof EndpointServiceGetEndpointsParamOffset
->;
-const EndpointServiceGetEndpointsParamPageNumber = z.number().int();
-type EndpointServiceGetEndpointsParamPageNumber = z.infer<
-  typeof EndpointServiceGetEndpointsParamPageNumber
->;
-const EndpointServiceGetEndpointsParamSortBy = z.string();
-type EndpointServiceGetEndpointsParamSortBy = z.infer<
-  typeof EndpointServiceGetEndpointsParamSortBy
->;
-const EndpointServiceGetEndpointsParamType = z.string();
-type EndpointServiceGetEndpointsParamType = z.infer<
-  typeof EndpointServiceGetEndpointsParamType
->;
-const EndpointServiceGetEndpointsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-type EndpointServiceGetEndpointsParamResponse200 = z.infer<
-  typeof EndpointServiceGetEndpointsParamResponse200
->;
-export interface EndpointServiceGetEndpoints {
-  active?: EndpointServiceGetEndpointsParamActive;
-  limit?: EndpointServiceGetEndpointsParamLimit;
-  offset?: EndpointServiceGetEndpointsParamOffset;
-  pageNumber?: EndpointServiceGetEndpointsParamPageNumber;
-  sortBy?: EndpointServiceGetEndpointsParamSortBy;
-  type?: EndpointServiceGetEndpointsParamType;
+  function zodSchemaUUID() {
+      return z.string();
+  }
+
+  function zodSchemaSetString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaNewCookie() {
+      return z.object({
+          domain: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          path: z.string().optional().nullable(),
+          value: z.string().optional().nullable(),
+          version: z.number().int().optional().nullable(),
+          comment: z.string().optional().nullable(),
+          expiry: zodSchemaDate().optional().nullable(),
+          httpOnly: z.boolean().optional().nullable(),
+          maxAge: z.number().int().optional().nullable(),
+          secure: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringNewCookie() {
+      return z.record(zodSchemaNewCookie());
+  }
+
+  function zodSchemaDate() {
+      return z.string();
+  }
+
+  function zodSchemaEntityTag() {
+      return z.object({
+          value: z.string().optional().nullable(),
+          weak: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringObject() {
+      return z.record(z.unknown());
+  }
+
+  function zodSchemaLocale() {
+      return z.object({
+          country: z.string().optional().nullable(),
+          displayCountry: z.string().optional().nullable(),
+          displayLanguage: z.string().optional().nullable(),
+          displayName: z.string().optional().nullable(),
+          displayScript: z.string().optional().nullable(),
+          displayVariant: z.string().optional().nullable(),
+          extensionKeys: zodSchemaSetCharacter().optional().nullable(),
+          iSO3Country: z.string().optional().nullable(),
+          iSO3Language: z.string().optional().nullable(),
+          language: z.string().optional().nullable(),
+          script: z.string().optional().nullable(),
+          unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+          unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
+          variant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaLink() {
+      return z.object({
+          params: zodSchemaMapStringString().optional().nullable(),
+          rel: z.string().optional().nullable(),
+          rels: zodSchemaListString().optional().nullable(),
+          title: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          uri: zodSchemaURI().optional().nullable(),
+          uriBuilder: zodSchemaUriBuilder().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetLink() {
+      return z.array(zodSchemaLink());
+  }
+
+  function zodSchemaURI() {
+      return z.string();
+  }
+
+  function zodSchemaMediaType() {
+      return z.object({
+          parameters: zodSchemaMapStringString().optional().nullable(),
+          subtype: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          wildcardSubtype: z.boolean().optional().nullable(),
+          wildcardType: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaStatusType() {
+      return z.object({
+          family: zodSchemaFamily().optional().nullable(),
+          reasonPhrase: z.string().optional().nullable(),
+          statusCode: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaFamily() {
+      return z.enum([
+          'CLIENT_ERROR',
+          'INFORMATIONAL',
+          'OTHER',
+          'REDIRECTION',
+          'SERVER_ERROR',
+          'SUCCESSFUL'
+      ]);
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaListString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaUriBuilder() {
+      return z.unknown();
+  }
+
+  function zodSchemaSetCharacter() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaResponse() {
+      return z.object({
+          allowedMethods: zodSchemaSetString().optional().nullable(),
+          cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+          date: zodSchemaDate().optional().nullable(),
+          entity: z.unknown().optional().nullable(),
+          entityTag: zodSchemaEntityTag().optional().nullable(),
+          headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          language: zodSchemaLocale().optional().nullable(),
+          lastModified: zodSchemaDate().optional().nullable(),
+          length: z.number().int().optional().nullable(),
+          links: zodSchemaSetLink().optional().nullable(),
+          location: zodSchemaURI().optional().nullable(),
+          mediaType: zodSchemaMediaType().optional().nullable(),
+          metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          status: z.number().int().optional().nullable(),
+          statusInfo: zodSchemaStatusType().optional().nullable(),
+          stringHeaders: zodSchemaMultivaluedMapStringString()
+          .optional()
+          .nullable()
+      });
+  }
+
+  function zodSchemaAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaBasicAuthentication() {
+      return z.object({
+          password: z.string().optional().nullable(),
+          username: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaHttpType() {
+      return z.enum([ 'GET', 'POST', 'PUT' ]);
+  }
+
+  function zodSchemaWebhookAttributes() {
+      return z.object({
+          basic_authentication: zodSchemaBasicAuthentication()
+          .optional()
+          .nullable(),
+          disable_ssl_verification: z.boolean().optional().nullable(),
+          method: z.intersection(
+              zodSchemaHttpType(),
+              z.enum([ 'GET', 'POST', 'PUT' ])
+          ),
+          secret_token: z.string().optional().nullable(),
+          url: z.string()
+      });
+  }
+
+  function zodSchemaEmailAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaEndpointType() {
+      return z.enum([ 'webhook', 'email', 'default' ]);
+  }
+
+  function zodSchemaEndpoint() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          enabled: z.boolean().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          properties: z
+          .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
+          .optional()
+          .nullable(),
+          type: z.intersection(
+              zodSchemaEndpointType(),
+              z.enum([ 'webhook', 'email', 'default' ])
+          ),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaApplication() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          eventTypes: zodSchemaSetEventType().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetEndpoint() {
+      return z.array(zodSchemaEndpoint());
+  }
+
+  function zodSchemaEventType() {
+      return z.object({
+          application: z
+          .lazy(() => zodSchemaApplication())
+          .optional()
+          .nullable(),
+          description: z.string(),
+          endpoints: zodSchemaSetEndpoint().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaSetEventType() {
+      return z.array(zodSchemaEventType());
+  }
+
+  function zodSchemaNotification() {
+      return z.object({
+          endpoint: zodSchemaEndpoint().optional().nullable(),
+          payload: z.unknown().optional().nullable(),
+          tenant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaJsonObject() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaNotificationHistory() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          details: zodSchemaJsonObject().optional().nullable(),
+          endpointId: zodSchemaUUID().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          invocationResult: z.boolean().optional().nullable(),
+          invocationTime: z.number().int().optional().nullable()
+      });
+  }
 }
 
-export type EndpointServiceGetEndpointsPayload =
-  | ValidatedResponse<
-      'EndpointServiceGetEndpointsParamResponse200',
-      200,
-      EndpointServiceGetEndpointsParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceGetEndpoints = Action<
-  EndpointServiceGetEndpointsPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceGetEndpoints = (
-    params: EndpointServiceGetEndpoints
-): ActionEndpointServiceGetEndpoints => {
-    const path = '/api/integrations/v1.0/endpoints';
-    const query = {} as Record<string, any>;
-    if (params.active !== undefined) {
-        query.active = params.active.toString();
+export namespace Operations {
+  // GET /endpoints
+  export namespace EndpointServiceGetEndpoints {
+    const Active = z.boolean();
+    type Active = z.infer<typeof Active>;
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const PageNumber = z.number().int();
+    type PageNumber = z.infer<typeof PageNumber>;
+    const SortBy = z.string();
+    type SortBy = z.infer<typeof SortBy>;
+    const Type = z.string();
+    type Type = z.infer<typeof Type>;
+    const Response200 = z.array(Schemas.Endpoint);
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      active?: Active;
+      limit?: Limit;
+      offset?: Offset;
+      pageNumber?: PageNumber;
+      sortBy?: SortBy;
+      type?: Type;
     }
 
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints';
+        const query = {} as Record<string, any>;
+        if (params.active !== undefined) {
+            query.active = params.active;
+        }
+
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
+
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
+
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
+
+        if (params.type !== undefined) {
+            query.type = params.type;
+        }
+
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /endpoints
+  export namespace EndpointServiceCreateEndpoint {
+    export interface Params {
+      body: Schemas.Endpoint;
     }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
+    export type Payload =
+      | ValidatedResponse<'Endpoint', 200, Schemas.Endpoint>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints';
+        const query = {} as Record<string, any>;
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.Endpoint, 'Endpoint', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}
+  export namespace EndpointServiceGetEndpoint {
+    export interface Params {
+      id: Schemas.UUID;
     }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
+    export type Payload =
+      | ValidatedResponse<'Endpoint', 200, Schemas.Endpoint>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Endpoint, 'Endpoint', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /endpoints/{id}
+  export namespace EndpointServiceUpdateEndpoint {
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      id: Schemas.UUID;
+      body: Schemas.Endpoint;
     }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /endpoints/{id}
+  export namespace EndpointServiceDeleteEndpoint {
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      id: Schemas.UUID;
     }
 
-    if (params.type !== undefined) {
-        query.type = params.type.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /endpoints/{id}/enable
+  export namespace EndpointServiceEnableEndpoint {
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      id: Schemas.UUID;
     }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetEndpointsParamResponse200,
-                'EndpointServiceGetEndpointsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// POST /endpoints
-export interface EndpointServiceCreateEndpoint {
-  body: Endpoint;
-}
-
-export type EndpointServiceCreateEndpointPayload =
-  | ValidatedResponse<'Endpoint', 200, Endpoint>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceCreateEndpoint = Action<
-  EndpointServiceCreateEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceCreateEndpoint = (
-    params: EndpointServiceCreateEndpoint
-): ActionEndpointServiceCreateEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints';
-    const query = {} as Record<string, any>;
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(Endpoint, 'Endpoint', 200) ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}
-export interface EndpointServiceGetEndpoint {
-  id: UUID;
-}
-
-export type EndpointServiceGetEndpointPayload =
-  | ValidatedResponse<'Endpoint', 200, Endpoint>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceGetEndpoint = Action<
-  EndpointServiceGetEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceGetEndpoint = (
-    params: EndpointServiceGetEndpoint
-): ActionEndpointServiceGetEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Endpoint, 'Endpoint', 200) ]
-    })
-    .build();
-};
-
-// PUT /endpoints/{id}
-const EndpointServiceUpdateEndpointParamResponse200 = z.string();
-type EndpointServiceUpdateEndpointParamResponse200 = z.infer<
-  typeof EndpointServiceUpdateEndpointParamResponse200
->;
-export interface EndpointServiceUpdateEndpoint {
-  id: UUID;
-  body: Endpoint;
-}
-
-export type EndpointServiceUpdateEndpointPayload =
-  | ValidatedResponse<
-      'EndpointServiceUpdateEndpointParamResponse200',
-      200,
-      EndpointServiceUpdateEndpointParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceUpdateEndpoint = Action<
-  EndpointServiceUpdateEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceUpdateEndpoint = (
-    params: EndpointServiceUpdateEndpoint
-): ActionEndpointServiceUpdateEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceUpdateEndpointParamResponse200,
-                'EndpointServiceUpdateEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /endpoints/{id}
-const EndpointServiceDeleteEndpointParamResponse200 = z.string();
-type EndpointServiceDeleteEndpointParamResponse200 = z.infer<
-  typeof EndpointServiceDeleteEndpointParamResponse200
->;
-export interface EndpointServiceDeleteEndpoint {
-  id: UUID;
-}
-
-export type EndpointServiceDeleteEndpointPayload =
-  | ValidatedResponse<
-      'EndpointServiceDeleteEndpointParamResponse200',
-      200,
-      EndpointServiceDeleteEndpointParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceDeleteEndpoint = Action<
-  EndpointServiceDeleteEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceDeleteEndpoint = (
-    params: EndpointServiceDeleteEndpoint
-): ActionEndpointServiceDeleteEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceDeleteEndpointParamResponse200,
-                'EndpointServiceDeleteEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// PUT /endpoints/{id}/enable
-const EndpointServiceEnableEndpointParamResponse200 = z.string();
-type EndpointServiceEnableEndpointParamResponse200 = z.infer<
-  typeof EndpointServiceEnableEndpointParamResponse200
->;
-export interface EndpointServiceEnableEndpoint {
-  id: UUID;
-}
-
-export type EndpointServiceEnableEndpointPayload =
-  | ValidatedResponse<
-      'EndpointServiceEnableEndpointParamResponse200',
-      200,
-      EndpointServiceEnableEndpointParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceEnableEndpoint = Action<
-  EndpointServiceEnableEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceEnableEndpoint = (
-    params: EndpointServiceEnableEndpoint
-): ActionEndpointServiceEnableEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceEnableEndpointParamResponse200,
-                'EndpointServiceEnableEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /endpoints/{id}/enable
-const EndpointServiceDisableEndpointParamResponse200 = z.string();
-type EndpointServiceDisableEndpointParamResponse200 = z.infer<
-  typeof EndpointServiceDisableEndpointParamResponse200
->;
-export interface EndpointServiceDisableEndpoint {
-  id: UUID;
-}
-
-export type EndpointServiceDisableEndpointPayload =
-  | ValidatedResponse<
-      'EndpointServiceDisableEndpointParamResponse200',
-      200,
-      EndpointServiceDisableEndpointParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceDisableEndpoint = Action<
-  EndpointServiceDisableEndpointPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceDisableEndpoint = (
-    params: EndpointServiceDisableEndpoint
-): ActionEndpointServiceDisableEndpoint => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceDisableEndpointParamResponse200,
-                'EndpointServiceDisableEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}/history
-const EndpointServiceGetEndpointHistoryParamResponse200 = z.array(
-    zodSchemaNotificationHistory()
-);
-type EndpointServiceGetEndpointHistoryParamResponse200 = z.infer<
-  typeof EndpointServiceGetEndpointHistoryParamResponse200
->;
-export interface EndpointServiceGetEndpointHistory {
-  id: UUID;
-}
-
-export type EndpointServiceGetEndpointHistoryPayload =
-  | ValidatedResponse<
-      'EndpointServiceGetEndpointHistoryParamResponse200',
-      200,
-      EndpointServiceGetEndpointHistoryParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceGetEndpointHistory = Action<
-  EndpointServiceGetEndpointHistoryPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceGetEndpointHistory = (
-    params: EndpointServiceGetEndpointHistory
-): ActionEndpointServiceGetEndpointHistory => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/history'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetEndpointHistoryParamResponse200,
-                'EndpointServiceGetEndpointHistoryParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}/history/{history_id}/details
-const EndpointServiceGetDetailedEndpointHistoryParamHistoryId = z
-.number()
-.int();
-type EndpointServiceGetDetailedEndpointHistoryParamHistoryId = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamHistoryId
->;
-const EndpointServiceGetDetailedEndpointHistoryParamLimit = z.number().int();
-type EndpointServiceGetDetailedEndpointHistoryParamLimit = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamLimit
->;
-const EndpointServiceGetDetailedEndpointHistoryParamOffset = z.number().int();
-type EndpointServiceGetDetailedEndpointHistoryParamOffset = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamOffset
->;
-const EndpointServiceGetDetailedEndpointHistoryParamPageNumber = z
-.number()
-.int();
-type EndpointServiceGetDetailedEndpointHistoryParamPageNumber = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamPageNumber
->;
-const EndpointServiceGetDetailedEndpointHistoryParamPageSize = z.number().int();
-type EndpointServiceGetDetailedEndpointHistoryParamPageSize = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamPageSize
->;
-const EndpointServiceGetDetailedEndpointHistoryParamSortBy = z.string();
-type EndpointServiceGetDetailedEndpointHistoryParamSortBy = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamSortBy
->;
-const EndpointServiceGetDetailedEndpointHistoryParamResponse200 = z.string();
-type EndpointServiceGetDetailedEndpointHistoryParamResponse200 = z.infer<
-  typeof EndpointServiceGetDetailedEndpointHistoryParamResponse200
->;
-export interface EndpointServiceGetDetailedEndpointHistory {
-  historyId: EndpointServiceGetDetailedEndpointHistoryParamHistoryId;
-  id: UUID;
-  limit?: EndpointServiceGetDetailedEndpointHistoryParamLimit;
-  offset?: EndpointServiceGetDetailedEndpointHistoryParamOffset;
-  pageNumber?: EndpointServiceGetDetailedEndpointHistoryParamPageNumber;
-  pageSize?: EndpointServiceGetDetailedEndpointHistoryParamPageSize;
-  sortBy?: EndpointServiceGetDetailedEndpointHistoryParamSortBy;
-}
-
-export type EndpointServiceGetDetailedEndpointHistoryPayload =
-  | ValidatedResponse<
-      'EndpointServiceGetDetailedEndpointHistoryParamResponse200',
-      200,
-      EndpointServiceGetDetailedEndpointHistoryParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionEndpointServiceGetDetailedEndpointHistory = Action<
-  EndpointServiceGetDetailedEndpointHistoryPayload,
-  ActionValidatableConfig
->;
-export const actionEndpointServiceGetDetailedEndpointHistory = (
-    params: EndpointServiceGetDetailedEndpointHistory
-): ActionEndpointServiceGetDetailedEndpointHistory => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/history/{history_id}/details'
-    .replace('{history_id}', params.historyId.toString())
-    .replace('{id}', params.id.toString());
-    const query = {} as Record<string, any>;
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /endpoints/{id}/enable
+  export namespace EndpointServiceDisableEndpoint {
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      id: Schemas.UUID;
     }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}/history
+  export namespace EndpointServiceGetEndpointHistory {
+    const Response200 = z.array(Schemas.NotificationHistory);
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      id: Schemas.UUID;
     }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/history'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}/history/{history_id}/details
+  export namespace EndpointServiceGetDetailedEndpointHistory {
+    const HistoryId = z.number().int();
+    type HistoryId = z.infer<typeof HistoryId>;
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const PageNumber = z.number().int();
+    type PageNumber = z.infer<typeof PageNumber>;
+    const PageSize = z.number().int();
+    type PageSize = z.infer<typeof PageSize>;
+    const SortBy = z.string();
+    type SortBy = z.infer<typeof SortBy>;
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      historyId: HistoryId;
+      id: Schemas.UUID;
+      limit?: Limit;
+      offset?: Offset;
+      pageNumber?: PageNumber;
+      pageSize?: PageSize;
+      sortBy?: SortBy;
     }
 
-    if (params.pageSize !== undefined) {
-        query.pageSize = params.pageSize.toString();
-    }
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/history/{history_id}/details'
+        .replace('{history_id}', params.historyId.toString())
+        .replace('{id}', params.id.toString());
+        const query = {} as Record<string, any>;
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetDetailedEndpointHistoryParamResponse200,
-                'EndpointServiceGetDetailedEndpointHistoryParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
 
-export function zodSchemaUUID() {
-    return z.string();
-}
+        if (params.pageSize !== undefined) {
+            query.pageSize = params.pageSize;
+        }
 
-export function zodSchemaSetString() {
-    return z.array(z.string());
-}
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
 
-export function zodSchemaNewCookie() {
-    return z.object({
-        domain: z.string().optional().nullable(),
-        name: z.string().optional().nullable(),
-        path: z.string().optional().nullable(),
-        value: z.string().optional().nullable(),
-        version: z.number().int().optional().nullable(),
-        comment: z.string().optional().nullable(),
-        expiry: zodSchemaDate().optional().nullable(),
-        httpOnly: z.boolean().optional().nullable(),
-        maxAge: z.number().int().optional().nullable(),
-        secure: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMapStringNewCookie() {
-    return z.record(zodSchemaNewCookie());
-}
-
-export function zodSchemaDate() {
-    return z.string();
-}
-
-export function zodSchemaEntityTag() {
-    return z.object({
-        value: z.string().optional().nullable(),
-        weak: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringObject() {
-    return z.record(z.unknown());
-}
-
-export function zodSchemaLocale() {
-    return z.object({
-        country: z.string().optional().nullable(),
-        displayCountry: z.string().optional().nullable(),
-        displayLanguage: z.string().optional().nullable(),
-        displayName: z.string().optional().nullable(),
-        displayScript: z.string().optional().nullable(),
-        displayVariant: z.string().optional().nullable(),
-        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
-        iSO3Country: z.string().optional().nullable(),
-        iSO3Language: z.string().optional().nullable(),
-        language: z.string().optional().nullable(),
-        script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
-        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
-        variant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaLink() {
-    return z.object({
-        params: zodSchemaMapStringString().optional().nullable(),
-        rel: z.string().optional().nullable(),
-        rels: zodSchemaListString().optional().nullable(),
-        title: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        uri: zodSchemaURI().optional().nullable(),
-        uriBuilder: zodSchemaUriBuilder().optional().nullable()
-    });
-}
-
-export function zodSchemaSetLink() {
-    return z.array(zodSchemaLink());
-}
-
-export function zodSchemaURI() {
-    return z.string();
-}
-
-export function zodSchemaMediaType() {
-    return z.object({
-        parameters: zodSchemaMapStringString().optional().nullable(),
-        subtype: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        wildcardSubtype: z.boolean().optional().nullable(),
-        wildcardType: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaStatusType() {
-    return z.object({
-        family: zodSchemaFamily().optional().nullable(),
-        reasonPhrase: z.string().optional().nullable(),
-        statusCode: z.number().int().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaFamily() {
-    return z.enum([
-        'CLIENT_ERROR',
-        'INFORMATIONAL',
-        'OTHER',
-        'REDIRECTION',
-        'SERVER_ERROR',
-        'SUCCESSFUL'
-    ]);
-}
-
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaListString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaUriBuilder() {
-    return z.unknown();
-}
-
-export function zodSchemaSetCharacter() {
-    return z.array(z.string());
-}
-
-export function zodSchemaResponse() {
-    return z.object({
-        allowedMethods: zodSchemaSetString().optional().nullable(),
-        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
-        date: zodSchemaDate().optional().nullable(),
-        entity: z.unknown().optional().nullable(),
-        entityTag: zodSchemaEntityTag().optional().nullable(),
-        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        language: zodSchemaLocale().optional().nullable(),
-        lastModified: zodSchemaDate().optional().nullable(),
-        length: z.number().int().optional().nullable(),
-        links: zodSchemaSetLink().optional().nullable(),
-        location: zodSchemaURI().optional().nullable(),
-        mediaType: zodSchemaMediaType().optional().nullable(),
-        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        status: z.number().int().optional().nullable(),
-        statusInfo: zodSchemaStatusType().optional().nullable(),
-        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
-    });
-}
-
-export function zodSchemaAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaBasicAuthentication() {
-    return z.object({
-        password: z.string().optional().nullable(),
-        username: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaHttpType() {
-    return z.enum([ 'GET', 'POST', 'PUT' ]);
-}
-
-export function zodSchemaWebhookAttributes() {
-    return z.object({
-        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
-        disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
-        secret_token: z.string().optional().nullable(),
-        url: z.string()
-    });
-}
-
-export function zodSchemaEmailAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaEndpointType() {
-    return z.enum([ 'webhook', 'email', 'default' ]);
-}
-
-export function zodSchemaEndpoint() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        enabled: z.boolean().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        properties: z
-        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
-        .optional()
-        .nullable(),
-        type: z.intersection(
-            zodSchemaEndpointType(),
-            z.enum([ 'webhook', 'email', 'default' ])
-        ),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaApplication() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        eventTypes: zodSchemaSetEventType().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaSetEndpoint() {
-    return z.array(zodSchemaEndpoint());
-}
-
-export function zodSchemaEventType() {
-    return z.object({
-        application: z
-        .lazy(() => zodSchemaApplication())
-        .optional()
-        .nullable(),
-        description: z.string(),
-        endpoints: zodSchemaSetEndpoint().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        name: z.string()
-    });
-}
-
-export function zodSchemaSetEventType() {
-    return z.array(zodSchemaEventType());
-}
-
-export function zodSchemaNotification() {
-    return z.object({
-        endpoint: zodSchemaEndpoint().optional().nullable(),
-        payload: z.unknown().optional().nullable(),
-        tenant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaJsonObject() {
-    return z.array(z.unknown());
-}
-
-export function zodSchemaNotificationHistory() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        details: zodSchemaJsonObject().optional().nullable(),
-        endpointId: zodSchemaUUID().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        invocationResult: z.boolean().optional().nullable(),
-        invocationTime: z.number().int().optional().nullable()
-    });
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -846,621 +706,592 @@ import * as z from 'zod';
 import { ValidateRule } from 'openapi2typescript';
 import { actionBuilder } from 'openapi2typescript/react-fetching-library';
 
-export const UUID = zodSchemaUUID();
+export namespace Schemas {
+  export const UUID = zodSchemaUUID();
 
-export const SetString = zodSchemaSetString();
+  export const SetString = zodSchemaSetString();
 
-export const NewCookie = zodSchemaNewCookie();
+  export const NewCookie = zodSchemaNewCookie();
 
-export const MapStringNewCookie = zodSchemaMapStringNewCookie();
+  export const MapStringNewCookie = zodSchemaMapStringNewCookie();
 
-export const Date = zodSchemaDate();
+  export const Date = zodSchemaDate();
 
-export const EntityTag = zodSchemaEntityTag();
+  export const EntityTag = zodSchemaEntityTag();
 
-export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
+  export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
 
-export const Locale = zodSchemaLocale();
+  export const Locale = zodSchemaLocale();
 
-export const Link = zodSchemaLink();
+  export const Link = zodSchemaLink();
 
-export const SetLink = zodSchemaSetLink();
+  export const SetLink = zodSchemaSetLink();
 
-export const URI = zodSchemaURI();
+  export const URI = zodSchemaURI();
 
-export const MediaType = zodSchemaMediaType();
+  export const MediaType = zodSchemaMediaType();
 
-export const StatusType = zodSchemaStatusType();
+  export const StatusType = zodSchemaStatusType();
 
-export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
+  export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
 
-export const Family = zodSchemaFamily();
+  export const Family = zodSchemaFamily();
 
-export const MapStringString = zodSchemaMapStringString();
+  export const MapStringString = zodSchemaMapStringString();
 
-export const ListString = zodSchemaListString();
+  export const ListString = zodSchemaListString();
 
-export const UriBuilder = zodSchemaUriBuilder();
+  export const UriBuilder = zodSchemaUriBuilder();
 
-export const SetCharacter = zodSchemaSetCharacter();
+  export const SetCharacter = zodSchemaSetCharacter();
 
-export const Response = zodSchemaResponse();
+  export const Response = zodSchemaResponse();
 
-export const Attributes = zodSchemaAttributes();
+  export const Attributes = zodSchemaAttributes();
 
-export const BasicAuthentication = zodSchemaBasicAuthentication();
+  export const BasicAuthentication = zodSchemaBasicAuthentication();
 
-export const HttpType = zodSchemaHttpType();
+  export const HttpType = zodSchemaHttpType();
 
-export const WebhookAttributes = zodSchemaWebhookAttributes();
+  export const WebhookAttributes = zodSchemaWebhookAttributes();
 
-export const EmailAttributes = zodSchemaEmailAttributes();
+  export const EmailAttributes = zodSchemaEmailAttributes();
 
-export const EndpointType = zodSchemaEndpointType();
+  export const EndpointType = zodSchemaEndpointType();
 
-export const Endpoint = zodSchemaEndpoint();
+  export const Endpoint = zodSchemaEndpoint();
 
-export const Application = zodSchemaApplication();
+  export const Application = zodSchemaApplication();
 
-export const SetEndpoint = zodSchemaSetEndpoint();
+  export const SetEndpoint = zodSchemaSetEndpoint();
 
-export const EventType = zodSchemaEventType();
+  export const EventType = zodSchemaEventType();
 
-export const SetEventType = zodSchemaSetEventType();
+  export const SetEventType = zodSchemaSetEventType();
 
-export const Notification = zodSchemaNotification();
+  export const Notification = zodSchemaNotification();
 
-export const JsonObject = zodSchemaJsonObject();
+  export const JsonObject = zodSchemaJsonObject();
 
-export const NotificationHistory = zodSchemaNotificationHistory();
+  export const NotificationHistory = zodSchemaNotificationHistory();
 
-// GET /endpoints
-const EndpointServiceGetEndpointsParamActive = z.boolean();
-const EndpointServiceGetEndpointsParamLimit = z.number().int();
-const EndpointServiceGetEndpointsParamOffset = z.number().int();
-const EndpointServiceGetEndpointsParamPageNumber = z.number().int();
-const EndpointServiceGetEndpointsParamSortBy = z.string();
-const EndpointServiceGetEndpointsParamType = z.string();
-const EndpointServiceGetEndpointsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-/*
+  function zodSchemaUUID() {
+      return z.string();
+  }
+
+  function zodSchemaSetString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaNewCookie() {
+      return z.object({
+          domain: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          path: z.string().optional().nullable(),
+          value: z.string().optional().nullable(),
+          version: z.number().int().optional().nullable(),
+          comment: z.string().optional().nullable(),
+          expiry: zodSchemaDate().optional().nullable(),
+          httpOnly: z.boolean().optional().nullable(),
+          maxAge: z.number().int().optional().nullable(),
+          secure: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringNewCookie() {
+      return z.record(zodSchemaNewCookie());
+  }
+
+  function zodSchemaDate() {
+      return z.string();
+  }
+
+  function zodSchemaEntityTag() {
+      return z.object({
+          value: z.string().optional().nullable(),
+          weak: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringObject() {
+      return z.record(z.unknown());
+  }
+
+  function zodSchemaLocale() {
+      return z.object({
+          country: z.string().optional().nullable(),
+          displayCountry: z.string().optional().nullable(),
+          displayLanguage: z.string().optional().nullable(),
+          displayName: z.string().optional().nullable(),
+          displayScript: z.string().optional().nullable(),
+          displayVariant: z.string().optional().nullable(),
+          extensionKeys: zodSchemaSetCharacter().optional().nullable(),
+          iSO3Country: z.string().optional().nullable(),
+          iSO3Language: z.string().optional().nullable(),
+          language: z.string().optional().nullable(),
+          script: z.string().optional().nullable(),
+          unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+          unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
+          variant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaLink() {
+      return z.object({
+          params: zodSchemaMapStringString().optional().nullable(),
+          rel: z.string().optional().nullable(),
+          rels: zodSchemaListString().optional().nullable(),
+          title: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          uri: zodSchemaURI().optional().nullable(),
+          uriBuilder: zodSchemaUriBuilder().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetLink() {
+      return z.array(zodSchemaLink());
+  }
+
+  function zodSchemaURI() {
+      return z.string();
+  }
+
+  function zodSchemaMediaType() {
+      return z.object({
+          parameters: zodSchemaMapStringString().optional().nullable(),
+          subtype: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          wildcardSubtype: z.boolean().optional().nullable(),
+          wildcardType: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaStatusType() {
+      return z.object({
+          family: zodSchemaFamily().optional().nullable(),
+          reasonPhrase: z.string().optional().nullable(),
+          statusCode: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaFamily() {
+      return z.enum([
+          'CLIENT_ERROR',
+          'INFORMATIONAL',
+          'OTHER',
+          'REDIRECTION',
+          'SERVER_ERROR',
+          'SUCCESSFUL'
+      ]);
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaListString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaUriBuilder() {
+      return z.unknown();
+  }
+
+  function zodSchemaSetCharacter() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaResponse() {
+      return z.object({
+          allowedMethods: zodSchemaSetString().optional().nullable(),
+          cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+          date: zodSchemaDate().optional().nullable(),
+          entity: z.unknown().optional().nullable(),
+          entityTag: zodSchemaEntityTag().optional().nullable(),
+          headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          language: zodSchemaLocale().optional().nullable(),
+          lastModified: zodSchemaDate().optional().nullable(),
+          length: z.number().int().optional().nullable(),
+          links: zodSchemaSetLink().optional().nullable(),
+          location: zodSchemaURI().optional().nullable(),
+          mediaType: zodSchemaMediaType().optional().nullable(),
+          metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          status: z.number().int().optional().nullable(),
+          statusInfo: zodSchemaStatusType().optional().nullable(),
+          stringHeaders: zodSchemaMultivaluedMapStringString()
+          .optional()
+          .nullable()
+      });
+  }
+
+  function zodSchemaAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaBasicAuthentication() {
+      return z.object({
+          password: z.string().optional().nullable(),
+          username: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaHttpType() {
+      return z.enum([ 'GET', 'POST', 'PUT' ]);
+  }
+
+  function zodSchemaWebhookAttributes() {
+      return z.object({
+          basic_authentication: zodSchemaBasicAuthentication()
+          .optional()
+          .nullable(),
+          disable_ssl_verification: z.boolean().optional().nullable(),
+          method: z.intersection(
+              zodSchemaHttpType(),
+              z.enum([ 'GET', 'POST', 'PUT' ])
+          ),
+          secret_token: z.string().optional().nullable(),
+          url: z.string()
+      });
+  }
+
+  function zodSchemaEmailAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaEndpointType() {
+      return z.enum([ 'webhook', 'email', 'default' ]);
+  }
+
+  function zodSchemaEndpoint() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          enabled: z.boolean().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          properties: z
+          .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
+          .optional()
+          .nullable(),
+          type: z.intersection(
+              zodSchemaEndpointType(),
+              z.enum([ 'webhook', 'email', 'default' ])
+          ),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaApplication() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          eventTypes: zodSchemaSetEventType().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetEndpoint() {
+      return z.array(zodSchemaEndpoint());
+  }
+
+  function zodSchemaEventType() {
+      return z.object({
+          application: z
+          .lazy(() => zodSchemaApplication())
+          .optional()
+          .nullable(),
+          description: z.string(),
+          endpoints: zodSchemaSetEndpoint().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaSetEventType() {
+      return z.array(zodSchemaEventType());
+  }
+
+  function zodSchemaNotification() {
+      return z.object({
+          endpoint: zodSchemaEndpoint().optional().nullable(),
+          payload: z.unknown().optional().nullable(),
+          tenant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaJsonObject() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaNotificationHistory() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          details: zodSchemaJsonObject().optional().nullable(),
+          endpointId: zodSchemaUUID().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          invocationResult: z.boolean().optional().nullable(),
+          invocationTime: z.number().int().optional().nullable()
+      });
+  }
+}
+
+export namespace Operations {
+  // GET /endpoints
+  export namespace EndpointServiceGetEndpoints {
+    const Active = z.boolean();
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const PageNumber = z.number().int();
+    const SortBy = z.string();
+    const Type = z.string();
+    const Response200 = z.array(Schemas.Endpoint);
+    /*
  Params
-'active'?:EndpointServiceGetEndpointsParamActive,
-'limit'?:EndpointServiceGetEndpointsParamLimit,
-'offset'?:EndpointServiceGetEndpointsParamOffset,
-'pageNumber'?:EndpointServiceGetEndpointsParamPageNumber,
-'sortBy'?:EndpointServiceGetEndpointsParamSortBy,
-'type'?:EndpointServiceGetEndpointsParamType
+'active'?:Active,
+'limit'?:Limit,
+'offset'?:Offset,
+'pageNumber'?:PageNumber,
+'sortBy'?:SortBy,
+'type'?:Type
 */
-export const actionEndpointServiceGetEndpoints = (params) => {
-    const path = '/api/integrations/v1.0/endpoints';
-    const query = {};
-    if (params.active !== undefined) {
-        query.active = params.active.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints';
+        const query = {};
+        if (params.active !== undefined) {
+            query.active = params.active;
+        }
 
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
-    }
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
 
-    if (params.type !== undefined) {
-        query.type = params.type.toString();
-    }
+        if (params.type !== undefined) {
+            query.type = params.type;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetEndpointsParamResponse200,
-                'EndpointServiceGetEndpointsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// POST /endpoints
-/*
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /endpoints
+  export namespace EndpointServiceCreateEndpoint {
+    /*
  Params
-body: Endpoint
+body: Schemas.Endpoint
 */
-export const actionEndpointServiceCreateEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints';
-    const query = {};
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(Endpoint, 'Endpoint', 200) ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints';
+        const query = {};
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.Endpoint, 'Endpoint', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}
+  export namespace EndpointServiceGetEndpoint {
+    /*
  Params
-'id':UUID
+'id':Schemas.UUID
 */
-export const actionEndpointServiceGetEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Endpoint, 'Endpoint', 200) ]
-    })
-    .build();
-};
-
-// PUT /endpoints/{id}
-const EndpointServiceUpdateEndpointParamResponse200 = z.string();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Endpoint, 'Endpoint', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /endpoints/{id}
+  export namespace EndpointServiceUpdateEndpoint {
+    const Response200 = z.string();
+    /*
  Params
-'id':UUID,
-body: Endpoint
+'id':Schemas.UUID,
+body: Schemas.Endpoint
 */
-export const actionEndpointServiceUpdateEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceUpdateEndpointParamResponse200,
-                'EndpointServiceUpdateEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /endpoints/{id}
-const EndpointServiceDeleteEndpointParamResponse200 = z.string();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /endpoints/{id}
+  export namespace EndpointServiceDeleteEndpoint {
+    const Response200 = z.string();
+    /*
  Params
-'id':UUID
+'id':Schemas.UUID
 */
-export const actionEndpointServiceDeleteEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceDeleteEndpointParamResponse200,
-                'EndpointServiceDeleteEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// PUT /endpoints/{id}/enable
-const EndpointServiceEnableEndpointParamResponse200 = z.string();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /endpoints/{id}/enable
+  export namespace EndpointServiceEnableEndpoint {
+    const Response200 = z.string();
+    /*
  Params
-'id':UUID
+'id':Schemas.UUID
 */
-export const actionEndpointServiceEnableEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceEnableEndpointParamResponse200,
-                'EndpointServiceEnableEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /endpoints/{id}/enable
-const EndpointServiceDisableEndpointParamResponse200 = z.string();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /endpoints/{id}/enable
+  export namespace EndpointServiceDisableEndpoint {
+    const Response200 = z.string();
+    /*
  Params
-'id':UUID
+'id':Schemas.UUID
 */
-export const actionEndpointServiceDisableEndpoint = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceDisableEndpointParamResponse200,
-                'EndpointServiceDisableEndpointParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}/history
-const EndpointServiceGetEndpointHistoryParamResponse200 = z.array(
-    zodSchemaNotificationHistory()
-);
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/enable'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}/history
+  export namespace EndpointServiceGetEndpointHistory {
+    const Response200 = z.array(Schemas.NotificationHistory);
+    /*
  Params
-'id':UUID
+'id':Schemas.UUID
 */
-export const actionEndpointServiceGetEndpointHistory = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/history'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetEndpointHistoryParamResponse200,
-                'EndpointServiceGetEndpointHistoryParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /endpoints/{id}/history/{history_id}/details
-const EndpointServiceGetDetailedEndpointHistoryParamHistoryId = z
-.number()
-.int();
-const EndpointServiceGetDetailedEndpointHistoryParamLimit = z.number().int();
-const EndpointServiceGetDetailedEndpointHistoryParamOffset = z.number().int();
-const EndpointServiceGetDetailedEndpointHistoryParamPageNumber = z
-.number()
-.int();
-const EndpointServiceGetDetailedEndpointHistoryParamPageSize = z.number().int();
-const EndpointServiceGetDetailedEndpointHistoryParamSortBy = z.string();
-const EndpointServiceGetDetailedEndpointHistoryParamResponse200 = z.string();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/history'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /endpoints/{id}/history/{history_id}/details
+  export namespace EndpointServiceGetDetailedEndpointHistory {
+    const HistoryId = z.number().int();
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const PageNumber = z.number().int();
+    const PageSize = z.number().int();
+    const SortBy = z.string();
+    const Response200 = z.string();
+    /*
  Params
-'historyId':EndpointServiceGetDetailedEndpointHistoryParamHistoryId,
-'id':UUID,
-'limit'?:EndpointServiceGetDetailedEndpointHistoryParamLimit,
-'offset'?:EndpointServiceGetDetailedEndpointHistoryParamOffset,
-'pageNumber'?:EndpointServiceGetDetailedEndpointHistoryParamPageNumber,
-'pageSize'?:EndpointServiceGetDetailedEndpointHistoryParamPageSize,
-'sortBy'?:EndpointServiceGetDetailedEndpointHistoryParamSortBy
+'historyId':HistoryId,
+'id':Schemas.UUID,
+'limit'?:Limit,
+'offset'?:Offset,
+'pageNumber'?:PageNumber,
+'pageSize'?:PageSize,
+'sortBy'?:SortBy
 */
-export const actionEndpointServiceGetDetailedEndpointHistory = (params) => {
-    const path = '/api/integrations/v1.0/endpoints/{id}/history/{history_id}/details'
-    .replace('{history_id}', params.historyId.toString())
-    .replace('{id}', params.id.toString());
-    const query = {};
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/integrations/v1.0/endpoints/{id}/history/{history_id}/details'
+        .replace('{history_id}', params.historyId.toString())
+        .replace('{id}', params.id.toString());
+        const query = {};
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
-    }
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
 
-    if (params.pageSize !== undefined) {
-        query.pageSize = params.pageSize.toString();
-    }
+        if (params.pageSize !== undefined) {
+            query.pageSize = params.pageSize;
+        }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                EndpointServiceGetDetailedEndpointHistoryParamResponse200,
-                'EndpointServiceGetDetailedEndpointHistoryParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-export function zodSchemaUUID() {
-    return z.string();
-}
-
-export function zodSchemaSetString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaNewCookie() {
-    return z.object({
-        domain: z.string().optional().nullable(),
-        name: z.string().optional().nullable(),
-        path: z.string().optional().nullable(),
-        value: z.string().optional().nullable(),
-        version: z.number().int().optional().nullable(),
-        comment: z.string().optional().nullable(),
-        expiry: zodSchemaDate().optional().nullable(),
-        httpOnly: z.boolean().optional().nullable(),
-        maxAge: z.number().int().optional().nullable(),
-        secure: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMapStringNewCookie() {
-    return z.record(zodSchemaNewCookie());
-}
-
-export function zodSchemaDate() {
-    return z.string();
-}
-
-export function zodSchemaEntityTag() {
-    return z.object({
-        value: z.string().optional().nullable(),
-        weak: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringObject() {
-    return z.record(z.unknown());
-}
-
-export function zodSchemaLocale() {
-    return z.object({
-        country: z.string().optional().nullable(),
-        displayCountry: z.string().optional().nullable(),
-        displayLanguage: z.string().optional().nullable(),
-        displayName: z.string().optional().nullable(),
-        displayScript: z.string().optional().nullable(),
-        displayVariant: z.string().optional().nullable(),
-        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
-        iSO3Country: z.string().optional().nullable(),
-        iSO3Language: z.string().optional().nullable(),
-        language: z.string().optional().nullable(),
-        script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
-        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
-        variant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaLink() {
-    return z.object({
-        params: zodSchemaMapStringString().optional().nullable(),
-        rel: z.string().optional().nullable(),
-        rels: zodSchemaListString().optional().nullable(),
-        title: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        uri: zodSchemaURI().optional().nullable(),
-        uriBuilder: zodSchemaUriBuilder().optional().nullable()
-    });
-}
-
-export function zodSchemaSetLink() {
-    return z.array(zodSchemaLink());
-}
-
-export function zodSchemaURI() {
-    return z.string();
-}
-
-export function zodSchemaMediaType() {
-    return z.object({
-        parameters: zodSchemaMapStringString().optional().nullable(),
-        subtype: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        wildcardSubtype: z.boolean().optional().nullable(),
-        wildcardType: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaStatusType() {
-    return z.object({
-        family: zodSchemaFamily().optional().nullable(),
-        reasonPhrase: z.string().optional().nullable(),
-        statusCode: z.number().int().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaFamily() {
-    return z.enum([
-        'CLIENT_ERROR',
-        'INFORMATIONAL',
-        'OTHER',
-        'REDIRECTION',
-        'SERVER_ERROR',
-        'SUCCESSFUL'
-    ]);
-}
-
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaListString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaUriBuilder() {
-    return z.unknown();
-}
-
-export function zodSchemaSetCharacter() {
-    return z.array(z.string());
-}
-
-export function zodSchemaResponse() {
-    return z.object({
-        allowedMethods: zodSchemaSetString().optional().nullable(),
-        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
-        date: zodSchemaDate().optional().nullable(),
-        entity: z.unknown().optional().nullable(),
-        entityTag: zodSchemaEntityTag().optional().nullable(),
-        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        language: zodSchemaLocale().optional().nullable(),
-        lastModified: zodSchemaDate().optional().nullable(),
-        length: z.number().int().optional().nullable(),
-        links: zodSchemaSetLink().optional().nullable(),
-        location: zodSchemaURI().optional().nullable(),
-        mediaType: zodSchemaMediaType().optional().nullable(),
-        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        status: z.number().int().optional().nullable(),
-        statusInfo: zodSchemaStatusType().optional().nullable(),
-        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
-    });
-}
-
-export function zodSchemaAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaBasicAuthentication() {
-    return z.object({
-        password: z.string().optional().nullable(),
-        username: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaHttpType() {
-    return z.enum([ 'GET', 'POST', 'PUT' ]);
-}
-
-export function zodSchemaWebhookAttributes() {
-    return z.object({
-        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
-        disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
-        secret_token: z.string().optional().nullable(),
-        url: z.string()
-    });
-}
-
-export function zodSchemaEmailAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaEndpointType() {
-    return z.enum([ 'webhook', 'email', 'default' ]);
-}
-
-export function zodSchemaEndpoint() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        enabled: z.boolean().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        properties: z
-        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
-        .optional()
-        .nullable(),
-        type: z.intersection(
-            zodSchemaEndpointType(),
-            z.enum([ 'webhook', 'email', 'default' ])
-        ),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaApplication() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        eventTypes: zodSchemaSetEventType().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaSetEndpoint() {
-    return z.array(zodSchemaEndpoint());
-}
-
-export function zodSchemaEventType() {
-    return z.object({
-        application: z
-        .lazy(() => zodSchemaApplication())
-        .optional()
-        .nullable(),
-        description: z.string(),
-        endpoints: zodSchemaSetEndpoint().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        name: z.string()
-    });
-}
-
-export function zodSchemaSetEventType() {
-    return z.array(zodSchemaEventType());
-}
-
-export function zodSchemaNotification() {
-    return z.object({
-        endpoint: zodSchemaEndpoint().optional().nullable(),
-        payload: z.unknown().optional().nullable(),
-        tenant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaJsonObject() {
-    return z.array(z.unknown());
-}
-
-export function zodSchemaNotificationHistory() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        details: zodSchemaJsonObject().optional().nullable(),
-        endpointId: zodSchemaUUID().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        invocationResult: z.boolean().optional().nullable(),
-        invocationTime: z.number().int().optional().nullable()
-    });
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -1479,766 +1310,650 @@ import {
     ActionValidatableConfig
 } from 'openapi2typescript/react-fetching-library';
 
-export const UUID = zodSchemaUUID();
-export type UUID = z.infer<typeof UUID>;
+export namespace Schemas {
+  export const UUID = zodSchemaUUID();
+  export type UUID = z.infer<typeof UUID>;
 
-export const SetString = zodSchemaSetString();
-export type SetString = z.infer<typeof SetString>;
+  export const SetString = zodSchemaSetString();
+  export type SetString = z.infer<typeof SetString>;
 
-export const NewCookie = zodSchemaNewCookie();
-export type NewCookie = z.infer<typeof NewCookie>;
+  export const NewCookie = zodSchemaNewCookie();
+  export type NewCookie = z.infer<typeof NewCookie>;
 
-export const MapStringNewCookie = zodSchemaMapStringNewCookie();
-export type MapStringNewCookie = z.infer<typeof MapStringNewCookie>;
+  export const MapStringNewCookie = zodSchemaMapStringNewCookie();
+  export type MapStringNewCookie = z.infer<typeof MapStringNewCookie>;
 
-export const Date = zodSchemaDate();
-export type Date = z.infer<typeof Date>;
+  export const Date = zodSchemaDate();
+  export type Date = z.infer<typeof Date>;
 
-export const EntityTag = zodSchemaEntityTag();
-export type EntityTag = z.infer<typeof EntityTag>;
+  export const EntityTag = zodSchemaEntityTag();
+  export type EntityTag = z.infer<typeof EntityTag>;
 
-export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
-export type MultivaluedMapStringObject = z.infer<
-  typeof MultivaluedMapStringObject
->;
+  export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
+  export type MultivaluedMapStringObject = z.infer<
+    typeof MultivaluedMapStringObject
+  >;
 
-export const Locale = zodSchemaLocale();
-export type Locale = z.infer<typeof Locale>;
+  export const Locale = zodSchemaLocale();
+  export type Locale = z.infer<typeof Locale>;
 
-export const Link = zodSchemaLink();
-export type Link = z.infer<typeof Link>;
+  export const Link = zodSchemaLink();
+  export type Link = z.infer<typeof Link>;
 
-export const SetLink = zodSchemaSetLink();
-export type SetLink = z.infer<typeof SetLink>;
+  export const SetLink = zodSchemaSetLink();
+  export type SetLink = z.infer<typeof SetLink>;
 
-export const URI = zodSchemaURI();
-export type URI = z.infer<typeof URI>;
+  export const URI = zodSchemaURI();
+  export type URI = z.infer<typeof URI>;
 
-export const MediaType = zodSchemaMediaType();
-export type MediaType = z.infer<typeof MediaType>;
+  export const MediaType = zodSchemaMediaType();
+  export type MediaType = z.infer<typeof MediaType>;
 
-export const StatusType = zodSchemaStatusType();
-export type StatusType = z.infer<typeof StatusType>;
+  export const StatusType = zodSchemaStatusType();
+  export type StatusType = z.infer<typeof StatusType>;
 
-export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
-export type MultivaluedMapStringString = z.infer<
-  typeof MultivaluedMapStringString
->;
+  export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
+  export type MultivaluedMapStringString = z.infer<
+    typeof MultivaluedMapStringString
+  >;
 
-export const Family = zodSchemaFamily();
-export type Family = z.infer<typeof Family>;
+  export const Family = zodSchemaFamily();
+  export type Family = z.infer<typeof Family>;
 
-export const MapStringString = zodSchemaMapStringString();
-export type MapStringString = z.infer<typeof MapStringString>;
+  export const MapStringString = zodSchemaMapStringString();
+  export type MapStringString = z.infer<typeof MapStringString>;
 
-export const ListString = zodSchemaListString();
-export type ListString = z.infer<typeof ListString>;
+  export const ListString = zodSchemaListString();
+  export type ListString = z.infer<typeof ListString>;
 
-export const UriBuilder = zodSchemaUriBuilder();
-export type UriBuilder = z.infer<typeof UriBuilder>;
+  export const UriBuilder = zodSchemaUriBuilder();
+  export type UriBuilder = z.infer<typeof UriBuilder>;
 
-export const SetCharacter = zodSchemaSetCharacter();
-export type SetCharacter = z.infer<typeof SetCharacter>;
+  export const SetCharacter = zodSchemaSetCharacter();
+  export type SetCharacter = z.infer<typeof SetCharacter>;
 
-export const Response = zodSchemaResponse();
-export type Response = z.infer<typeof Response>;
+  export const Response = zodSchemaResponse();
+  export type Response = z.infer<typeof Response>;
 
-export const Attributes = zodSchemaAttributes();
-export type Attributes = z.infer<typeof Attributes>;
+  export const Attributes = zodSchemaAttributes();
+  export type Attributes = z.infer<typeof Attributes>;
 
-export const BasicAuthentication = zodSchemaBasicAuthentication();
-export type BasicAuthentication = z.infer<typeof BasicAuthentication>;
+  export const BasicAuthentication = zodSchemaBasicAuthentication();
+  export type BasicAuthentication = z.infer<typeof BasicAuthentication>;
 
-export const HttpType = zodSchemaHttpType();
-export type HttpType = z.infer<typeof HttpType>;
+  export const HttpType = zodSchemaHttpType();
+  export type HttpType = z.infer<typeof HttpType>;
 
-export const WebhookAttributes = zodSchemaWebhookAttributes();
-export type WebhookAttributes = z.infer<typeof WebhookAttributes>;
+  export const WebhookAttributes = zodSchemaWebhookAttributes();
+  export type WebhookAttributes = z.infer<typeof WebhookAttributes>;
 
-export const EmailAttributes = zodSchemaEmailAttributes();
-export type EmailAttributes = z.infer<typeof EmailAttributes>;
+  export const EmailAttributes = zodSchemaEmailAttributes();
+  export type EmailAttributes = z.infer<typeof EmailAttributes>;
 
-export const EndpointType = zodSchemaEndpointType();
-export type EndpointType = z.infer<typeof EndpointType>;
+  export const EndpointType = zodSchemaEndpointType();
+  export type EndpointType = z.infer<typeof EndpointType>;
 
-export const Endpoint = zodSchemaEndpoint();
-export type Endpoint = z.infer<typeof Endpoint>;
+  export const Endpoint = zodSchemaEndpoint();
+  export type Endpoint = z.infer<typeof Endpoint>;
 
-export const Application = zodSchemaApplication();
-export type Application = z.infer<typeof Application>;
+  export const Application = zodSchemaApplication();
+  export type Application = z.infer<typeof Application>;
 
-export const SetEndpoint = zodSchemaSetEndpoint();
-export type SetEndpoint = z.infer<typeof SetEndpoint>;
+  export const SetEndpoint = zodSchemaSetEndpoint();
+  export type SetEndpoint = z.infer<typeof SetEndpoint>;
 
-export const EventType = zodSchemaEventType();
-export type EventType = z.infer<typeof EventType>;
+  export const EventType = zodSchemaEventType();
+  export type EventType = z.infer<typeof EventType>;
 
-export const SetEventType = zodSchemaSetEventType();
-export type SetEventType = z.infer<typeof SetEventType>;
+  export const SetEventType = zodSchemaSetEventType();
+  export type SetEventType = z.infer<typeof SetEventType>;
 
-export const Notification = zodSchemaNotification();
-export type Notification = z.infer<typeof Notification>;
+  export const Notification = zodSchemaNotification();
+  export type Notification = z.infer<typeof Notification>;
 
-export const JsonObject = zodSchemaJsonObject();
-export type JsonObject = z.infer<typeof JsonObject>;
+  export const JsonObject = zodSchemaJsonObject();
+  export type JsonObject = z.infer<typeof JsonObject>;
 
-export const NotificationHistory = zodSchemaNotificationHistory();
-export type NotificationHistory = z.infer<typeof NotificationHistory>;
+  export const NotificationHistory = zodSchemaNotificationHistory();
+  export type NotificationHistory = z.infer<typeof NotificationHistory>;
 
-// GET /notifications/defaults
-const NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-type NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.infer<
-  typeof NotificationServiceGetEndpointsForDefaultsParamResponse200
->;
-export type NotificationServiceGetEndpointsForDefaultsPayload =
-  | ValidatedResponse<
-      'NotificationServiceGetEndpointsForDefaultsParamResponse200',
-      200,
-      NotificationServiceGetEndpointsForDefaultsParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceGetEndpointsForDefaults = Action<
-  NotificationServiceGetEndpointsForDefaultsPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceGetEndpointsForDefaults = (): ActionNotificationServiceGetEndpointsForDefaults => {
-    const path = '/api/notifications/v1.0/notifications/defaults';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetEndpointsForDefaultsParamResponse200,
-                'NotificationServiceGetEndpointsForDefaultsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
+  function zodSchemaUUID() {
+      return z.string();
+  }
 
-// PUT /notifications/defaults/{endpointId}
-export interface NotificationServiceAddEndpointToDefaults {
-  endpointId: UUID;
+  function zodSchemaSetString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaNewCookie() {
+      return z.object({
+          domain: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          path: z.string().optional().nullable(),
+          value: z.string().optional().nullable(),
+          version: z.number().int().optional().nullable(),
+          comment: z.string().optional().nullable(),
+          expiry: zodSchemaDate().optional().nullable(),
+          httpOnly: z.boolean().optional().nullable(),
+          maxAge: z.number().int().optional().nullable(),
+          secure: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringNewCookie() {
+      return z.record(zodSchemaNewCookie());
+  }
+
+  function zodSchemaDate() {
+      return z.string();
+  }
+
+  function zodSchemaEntityTag() {
+      return z.object({
+          value: z.string().optional().nullable(),
+          weak: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringObject() {
+      return z.record(z.unknown());
+  }
+
+  function zodSchemaLocale() {
+      return z.object({
+          country: z.string().optional().nullable(),
+          displayCountry: z.string().optional().nullable(),
+          displayLanguage: z.string().optional().nullable(),
+          displayName: z.string().optional().nullable(),
+          displayScript: z.string().optional().nullable(),
+          displayVariant: z.string().optional().nullable(),
+          extensionKeys: zodSchemaSetCharacter().optional().nullable(),
+          iSO3Country: z.string().optional().nullable(),
+          iSO3Language: z.string().optional().nullable(),
+          language: z.string().optional().nullable(),
+          script: z.string().optional().nullable(),
+          unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+          unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
+          variant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaLink() {
+      return z.object({
+          params: zodSchemaMapStringString().optional().nullable(),
+          rel: z.string().optional().nullable(),
+          rels: zodSchemaListString().optional().nullable(),
+          title: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          uri: zodSchemaURI().optional().nullable(),
+          uriBuilder: zodSchemaUriBuilder().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetLink() {
+      return z.array(zodSchemaLink());
+  }
+
+  function zodSchemaURI() {
+      return z.string();
+  }
+
+  function zodSchemaMediaType() {
+      return z.object({
+          parameters: zodSchemaMapStringString().optional().nullable(),
+          subtype: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          wildcardSubtype: z.boolean().optional().nullable(),
+          wildcardType: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaStatusType() {
+      return z.object({
+          family: zodSchemaFamily().optional().nullable(),
+          reasonPhrase: z.string().optional().nullable(),
+          statusCode: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaFamily() {
+      return z.enum([
+          'CLIENT_ERROR',
+          'INFORMATIONAL',
+          'OTHER',
+          'REDIRECTION',
+          'SERVER_ERROR',
+          'SUCCESSFUL'
+      ]);
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaListString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaUriBuilder() {
+      return z.unknown();
+  }
+
+  function zodSchemaSetCharacter() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaResponse() {
+      return z.object({
+          allowedMethods: zodSchemaSetString().optional().nullable(),
+          cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+          date: zodSchemaDate().optional().nullable(),
+          entity: z.unknown().optional().nullable(),
+          entityTag: zodSchemaEntityTag().optional().nullable(),
+          headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          language: zodSchemaLocale().optional().nullable(),
+          lastModified: zodSchemaDate().optional().nullable(),
+          length: z.number().int().optional().nullable(),
+          links: zodSchemaSetLink().optional().nullable(),
+          location: zodSchemaURI().optional().nullable(),
+          mediaType: zodSchemaMediaType().optional().nullable(),
+          metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          status: z.number().int().optional().nullable(),
+          statusInfo: zodSchemaStatusType().optional().nullable(),
+          stringHeaders: zodSchemaMultivaluedMapStringString()
+          .optional()
+          .nullable()
+      });
+  }
+
+  function zodSchemaAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaBasicAuthentication() {
+      return z.object({
+          password: z.string().optional().nullable(),
+          username: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaHttpType() {
+      return z.enum([ 'GET', 'POST', 'PUT' ]);
+  }
+
+  function zodSchemaWebhookAttributes() {
+      return z.object({
+          basic_authentication: zodSchemaBasicAuthentication()
+          .optional()
+          .nullable(),
+          disable_ssl_verification: z.boolean().optional().nullable(),
+          method: z.intersection(
+              zodSchemaHttpType(),
+              z.enum([ 'GET', 'POST', 'PUT' ])
+          ),
+          secret_token: z.string().optional().nullable(),
+          url: z.string()
+      });
+  }
+
+  function zodSchemaEmailAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaEndpointType() {
+      return z.enum([ 'webhook', 'email', 'default' ]);
+  }
+
+  function zodSchemaEndpoint() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          enabled: z.boolean().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          properties: z
+          .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
+          .optional()
+          .nullable(),
+          type: z.intersection(
+              zodSchemaEndpointType(),
+              z.enum([ 'webhook', 'email', 'default' ])
+          ),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaApplication() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          eventTypes: zodSchemaSetEventType().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetEndpoint() {
+      return z.array(zodSchemaEndpoint());
+  }
+
+  function zodSchemaEventType() {
+      return z.object({
+          application: z
+          .lazy(() => zodSchemaApplication())
+          .optional()
+          .nullable(),
+          description: z.string(),
+          endpoints: zodSchemaSetEndpoint().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaSetEventType() {
+      return z.array(zodSchemaEventType());
+  }
+
+  function zodSchemaNotification() {
+      return z.object({
+          endpoint: zodSchemaEndpoint().optional().nullable(),
+          payload: z.unknown().optional().nullable(),
+          tenant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaJsonObject() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaNotificationHistory() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          details: zodSchemaJsonObject().optional().nullable(),
+          endpointId: zodSchemaUUID().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          invocationResult: z.boolean().optional().nullable(),
+          invocationTime: z.number().int().optional().nullable()
+      });
+  }
 }
 
-export type NotificationServiceAddEndpointToDefaultsPayload =
-  | ValidatedResponse<'Response', 200, Response>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceAddEndpointToDefaults = Action<
-  NotificationServiceAddEndpointToDefaultsPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceAddEndpointToDefaults = (
-    params: NotificationServiceAddEndpointToDefaults
-): ActionNotificationServiceAddEndpointToDefaults => {
-    const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
-        '{endpointId}',
-        params.endpointId.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// DELETE /notifications/defaults/{endpointId}
-export interface NotificationServiceDeleteEndpointFromDefaults {
-  endpointId: UUID;
-}
-
-export type NotificationServiceDeleteEndpointFromDefaultsPayload =
-  | ValidatedResponse<'Response', 200, Response>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceDeleteEndpointFromDefaults = Action<
-  NotificationServiceDeleteEndpointFromDefaultsPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceDeleteEndpointFromDefaults = (
-    params: NotificationServiceDeleteEndpointFromDefaults
-): ActionNotificationServiceDeleteEndpointFromDefaults => {
-    const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
-        '{endpointId}',
-        params.endpointId.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// GET /notifications/eventTypes
-const NotificationServiceGetEventTypesParamLimit = z.number().int();
-type NotificationServiceGetEventTypesParamLimit = z.infer<
-  typeof NotificationServiceGetEventTypesParamLimit
->;
-const NotificationServiceGetEventTypesParamOffset = z.number().int();
-type NotificationServiceGetEventTypesParamOffset = z.infer<
-  typeof NotificationServiceGetEventTypesParamOffset
->;
-const NotificationServiceGetEventTypesParamPageNumber = z.number().int();
-type NotificationServiceGetEventTypesParamPageNumber = z.infer<
-  typeof NotificationServiceGetEventTypesParamPageNumber
->;
-const NotificationServiceGetEventTypesParamSortBy = z.string();
-type NotificationServiceGetEventTypesParamSortBy = z.infer<
-  typeof NotificationServiceGetEventTypesParamSortBy
->;
-const NotificationServiceGetEventTypesParamResponse200 = z.array(
-    zodSchemaEventType()
-);
-type NotificationServiceGetEventTypesParamResponse200 = z.infer<
-  typeof NotificationServiceGetEventTypesParamResponse200
->;
-export interface NotificationServiceGetEventTypes {
-  limit?: NotificationServiceGetEventTypesParamLimit;
-  offset?: NotificationServiceGetEventTypesParamOffset;
-  pageNumber?: NotificationServiceGetEventTypesParamPageNumber;
-  sortBy?: NotificationServiceGetEventTypesParamSortBy;
-}
-
-export type NotificationServiceGetEventTypesPayload =
-  | ValidatedResponse<
-      'NotificationServiceGetEventTypesParamResponse200',
-      200,
-      NotificationServiceGetEventTypesParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceGetEventTypes = Action<
-  NotificationServiceGetEventTypesPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceGetEventTypes = (
-    params: NotificationServiceGetEventTypes
-): ActionNotificationServiceGetEventTypes => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes';
-    const query = {} as Record<string, any>;
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
+export namespace Operations {
+  // GET /notifications/defaults
+  export namespace NotificationServiceGetEndpointsForDefaults {
+    const Response200 = z.array(Schemas.Endpoint);
+    type Response200 = z.infer<typeof Response200>;
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/defaults';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /notifications/defaults/{endpointId}
+  export namespace NotificationServiceAddEndpointToDefaults {
+    export interface Params {
+      endpointId: Schemas.UUID;
     }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
+    export type Payload =
+      | ValidatedResponse<'Response', 200, Schemas.Response>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
+            '{endpointId}',
+            params.endpointId.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/defaults/{endpointId}
+  export namespace NotificationServiceDeleteEndpointFromDefaults {
+    export interface Params {
+      endpointId: Schemas.UUID;
     }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
+    export type Payload =
+      | ValidatedResponse<'Response', 200, Schemas.Response>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
+            '{endpointId}',
+            params.endpointId.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/eventTypes
+  export namespace NotificationServiceGetEventTypes {
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const PageNumber = z.number().int();
+    type PageNumber = z.infer<typeof PageNumber>;
+    const SortBy = z.string();
+    type SortBy = z.infer<typeof SortBy>;
+    const Response200 = z.array(Schemas.EventType);
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      limit?: Limit;
+      offset?: Offset;
+      pageNumber?: PageNumber;
+      sortBy?: SortBy;
     }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes';
+        const query = {} as Record<string, any>;
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
+
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
+
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
+
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/eventTypes/{eventTypeId}
+  export namespace NotificationServiceGetLinkedEndpoints {
+    const EventTypeId = z.number().int();
+    type EventTypeId = z.infer<typeof EventTypeId>;
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const PageNumber = z.number().int();
+    type PageNumber = z.infer<typeof PageNumber>;
+    const SortBy = z.string();
+    type SortBy = z.infer<typeof SortBy>;
+    const Response200 = z.array(Schemas.Endpoint);
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      eventTypeId: EventTypeId;
+      limit?: Limit;
+      offset?: Offset;
+      pageNumber?: PageNumber;
+      sortBy?: SortBy;
     }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetEventTypesParamResponse200,
-                'NotificationServiceGetEventTypesParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}'.replace(
+            '{eventTypeId}',
+            params.eventTypeId.toString()
+        );
+        const query = {} as Record<string, any>;
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-// GET /notifications/eventTypes/{eventTypeId}
-const NotificationServiceGetLinkedEndpointsParamEventTypeId = z.number().int();
-type NotificationServiceGetLinkedEndpointsParamEventTypeId = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamEventTypeId
->;
-const NotificationServiceGetLinkedEndpointsParamLimit = z.number().int();
-type NotificationServiceGetLinkedEndpointsParamLimit = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamLimit
->;
-const NotificationServiceGetLinkedEndpointsParamOffset = z.number().int();
-type NotificationServiceGetLinkedEndpointsParamOffset = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamOffset
->;
-const NotificationServiceGetLinkedEndpointsParamPageNumber = z.number().int();
-type NotificationServiceGetLinkedEndpointsParamPageNumber = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamPageNumber
->;
-const NotificationServiceGetLinkedEndpointsParamSortBy = z.string();
-type NotificationServiceGetLinkedEndpointsParamSortBy = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamSortBy
->;
-const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-type NotificationServiceGetLinkedEndpointsParamResponse200 = z.infer<
-  typeof NotificationServiceGetLinkedEndpointsParamResponse200
->;
-export interface NotificationServiceGetLinkedEndpoints {
-  eventTypeId: NotificationServiceGetLinkedEndpointsParamEventTypeId;
-  limit?: NotificationServiceGetLinkedEndpointsParamLimit;
-  offset?: NotificationServiceGetLinkedEndpointsParamOffset;
-  pageNumber?: NotificationServiceGetLinkedEndpointsParamPageNumber;
-  sortBy?: NotificationServiceGetLinkedEndpointsParamSortBy;
-}
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-export type NotificationServiceGetLinkedEndpointsPayload =
-  | ValidatedResponse<
-      'NotificationServiceGetLinkedEndpointsParamResponse200',
-      200,
-      NotificationServiceGetLinkedEndpointsParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceGetLinkedEndpoints = Action<
-  NotificationServiceGetLinkedEndpointsPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceGetLinkedEndpoints = (
-    params: NotificationServiceGetLinkedEndpoints
-): ActionNotificationServiceGetLinkedEndpoints => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}'.replace(
-        '{eventTypeId}',
-        params.eventTypeId.toString()
-    );
-    const query = {} as Record<string, any>;
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
+
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
+
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /notifications/eventTypes/{eventTypeId}/{endpointId}
+  export namespace NotificationServiceLinkEndpointToEventType {
+    const EventTypeId = z.number().int();
+    type EventTypeId = z.infer<typeof EventTypeId>;
+    const Response200 = z.string();
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      endpointId: Schemas.UUID;
+      eventTypeId: EventTypeId;
     }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
+        .replace('{endpointId}', params.endpointId.toString())
+        .replace('{eventTypeId}', params.eventTypeId.toString());
+        const query = {} as Record<string, any>;
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/eventTypes/{eventTypeId}/{endpointId}
+  export namespace NotificationServiceUnlinkEndpointFromEventType {
+    const EventTypeId = z.number().int();
+    type EventTypeId = z.infer<typeof EventTypeId>;
+    export interface Params {
+      endpointId: Schemas.UUID;
+      eventTypeId: EventTypeId;
     }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
+    export type Payload =
+      | ValidatedResponse<'Response', 200, Schemas.Response>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
+        .replace('{endpointId}', params.endpointId.toString())
+        .replace('{eventTypeId}', params.eventTypeId.toString());
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/updates
+  export namespace NotificationServiceGetNotificationUpdates {
+    const Response200 = z.array(Schemas.Notification);
+    type Response200 = z.infer<typeof Response200>;
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/updates';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/{id}
+  export namespace NotificationServiceMarkRead {
+    const Body = z.number().int();
+    type Body = z.infer<typeof Body>;
+    export interface Params {
+      body: Body;
     }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetLinkedEndpointsParamResponse200,
-                'NotificationServiceGetLinkedEndpointsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// PUT /notifications/eventTypes/{eventTypeId}/{endpointId}
-const NotificationServiceLinkEndpointToEventTypeParamEventTypeId = z
-.number()
-.int();
-type NotificationServiceLinkEndpointToEventTypeParamEventTypeId = z.infer<
-  typeof NotificationServiceLinkEndpointToEventTypeParamEventTypeId
->;
-const NotificationServiceLinkEndpointToEventTypeParamResponse200 = z.string();
-type NotificationServiceLinkEndpointToEventTypeParamResponse200 = z.infer<
-  typeof NotificationServiceLinkEndpointToEventTypeParamResponse200
->;
-export interface NotificationServiceLinkEndpointToEventType {
-  endpointId: UUID;
-  eventTypeId: NotificationServiceLinkEndpointToEventTypeParamEventTypeId;
-}
-
-export type NotificationServiceLinkEndpointToEventTypePayload =
-  | ValidatedResponse<
-      'NotificationServiceLinkEndpointToEventTypeParamResponse200',
-      200,
-      NotificationServiceLinkEndpointToEventTypeParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceLinkEndpointToEventType = Action<
-  NotificationServiceLinkEndpointToEventTypePayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceLinkEndpointToEventType = (
-    params: NotificationServiceLinkEndpointToEventType
-): ActionNotificationServiceLinkEndpointToEventType => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
-    .replace('{endpointId}', params.endpointId.toString())
-    .replace('{eventTypeId}', params.eventTypeId.toString());
-    const query = {} as Record<string, any>;
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceLinkEndpointToEventTypeParamResponse200,
-                'NotificationServiceLinkEndpointToEventTypeParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /notifications/eventTypes/{eventTypeId}/{endpointId}
-const NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId = z
-.number()
-.int();
-type NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId = z.infer<
-  typeof NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId
->;
-export interface NotificationServiceUnlinkEndpointFromEventType {
-  endpointId: UUID;
-  eventTypeId: NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId;
-}
-
-export type NotificationServiceUnlinkEndpointFromEventTypePayload =
-  | ValidatedResponse<'Response', 200, Response>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceUnlinkEndpointFromEventType = Action<
-  NotificationServiceUnlinkEndpointFromEventTypePayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceUnlinkEndpointFromEventType = (
-    params: NotificationServiceUnlinkEndpointFromEventType
-): ActionNotificationServiceUnlinkEndpointFromEventType => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
-    .replace('{endpointId}', params.endpointId.toString())
-    .replace('{eventTypeId}', params.eventTypeId.toString());
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// GET /notifications/updates
-const NotificationServiceGetNotificationUpdatesParamResponse200 = z.array(
-    zodSchemaNotification()
-);
-type NotificationServiceGetNotificationUpdatesParamResponse200 = z.infer<
-  typeof NotificationServiceGetNotificationUpdatesParamResponse200
->;
-export type NotificationServiceGetNotificationUpdatesPayload =
-  | ValidatedResponse<
-      'NotificationServiceGetNotificationUpdatesParamResponse200',
-      200,
-      NotificationServiceGetNotificationUpdatesParamResponse200
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceGetNotificationUpdates = Action<
-  NotificationServiceGetNotificationUpdatesPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceGetNotificationUpdates = (): ActionNotificationServiceGetNotificationUpdates => {
-    const path = '/api/notifications/v1.0/notifications/updates';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetNotificationUpdatesParamResponse200,
-                'NotificationServiceGetNotificationUpdatesParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /notifications/{id}
-const NotificationServiceMarkReadParamBody = z.number().int();
-type NotificationServiceMarkReadParamBody = z.infer<
-  typeof NotificationServiceMarkReadParamBody
->;
-export interface NotificationServiceMarkRead {
-  body: NotificationServiceMarkReadParamBody;
-}
-
-export type NotificationServiceMarkReadPayload =
-  | ValidatedResponse<'Response', 200, Response>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionNotificationServiceMarkRead = Action<
-  NotificationServiceMarkReadPayload,
-  ActionValidatableConfig
->;
-export const actionNotificationServiceMarkRead = (
-    params: NotificationServiceMarkRead
-): ActionNotificationServiceMarkRead => {
-    const path = '/api/notifications/v1.0/notifications/{id}';
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-export function zodSchemaUUID() {
-    return z.string();
-}
-
-export function zodSchemaSetString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaNewCookie() {
-    return z.object({
-        domain: z.string().optional().nullable(),
-        name: z.string().optional().nullable(),
-        path: z.string().optional().nullable(),
-        value: z.string().optional().nullable(),
-        version: z.number().int().optional().nullable(),
-        comment: z.string().optional().nullable(),
-        expiry: zodSchemaDate().optional().nullable(),
-        httpOnly: z.boolean().optional().nullable(),
-        maxAge: z.number().int().optional().nullable(),
-        secure: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMapStringNewCookie() {
-    return z.record(zodSchemaNewCookie());
-}
-
-export function zodSchemaDate() {
-    return z.string();
-}
-
-export function zodSchemaEntityTag() {
-    return z.object({
-        value: z.string().optional().nullable(),
-        weak: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringObject() {
-    return z.record(z.unknown());
-}
-
-export function zodSchemaLocale() {
-    return z.object({
-        country: z.string().optional().nullable(),
-        displayCountry: z.string().optional().nullable(),
-        displayLanguage: z.string().optional().nullable(),
-        displayName: z.string().optional().nullable(),
-        displayScript: z.string().optional().nullable(),
-        displayVariant: z.string().optional().nullable(),
-        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
-        iSO3Country: z.string().optional().nullable(),
-        iSO3Language: z.string().optional().nullable(),
-        language: z.string().optional().nullable(),
-        script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
-        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
-        variant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaLink() {
-    return z.object({
-        params: zodSchemaMapStringString().optional().nullable(),
-        rel: z.string().optional().nullable(),
-        rels: zodSchemaListString().optional().nullable(),
-        title: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        uri: zodSchemaURI().optional().nullable(),
-        uriBuilder: zodSchemaUriBuilder().optional().nullable()
-    });
-}
-
-export function zodSchemaSetLink() {
-    return z.array(zodSchemaLink());
-}
-
-export function zodSchemaURI() {
-    return z.string();
-}
-
-export function zodSchemaMediaType() {
-    return z.object({
-        parameters: zodSchemaMapStringString().optional().nullable(),
-        subtype: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        wildcardSubtype: z.boolean().optional().nullable(),
-        wildcardType: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaStatusType() {
-    return z.object({
-        family: zodSchemaFamily().optional().nullable(),
-        reasonPhrase: z.string().optional().nullable(),
-        statusCode: z.number().int().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaFamily() {
-    return z.enum([
-        'CLIENT_ERROR',
-        'INFORMATIONAL',
-        'OTHER',
-        'REDIRECTION',
-        'SERVER_ERROR',
-        'SUCCESSFUL'
-    ]);
-}
-
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaListString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaUriBuilder() {
-    return z.unknown();
-}
-
-export function zodSchemaSetCharacter() {
-    return z.array(z.string());
-}
-
-export function zodSchemaResponse() {
-    return z.object({
-        allowedMethods: zodSchemaSetString().optional().nullable(),
-        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
-        date: zodSchemaDate().optional().nullable(),
-        entity: z.unknown().optional().nullable(),
-        entityTag: zodSchemaEntityTag().optional().nullable(),
-        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        language: zodSchemaLocale().optional().nullable(),
-        lastModified: zodSchemaDate().optional().nullable(),
-        length: z.number().int().optional().nullable(),
-        links: zodSchemaSetLink().optional().nullable(),
-        location: zodSchemaURI().optional().nullable(),
-        mediaType: zodSchemaMediaType().optional().nullable(),
-        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        status: z.number().int().optional().nullable(),
-        statusInfo: zodSchemaStatusType().optional().nullable(),
-        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
-    });
-}
-
-export function zodSchemaAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaBasicAuthentication() {
-    return z.object({
-        password: z.string().optional().nullable(),
-        username: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaHttpType() {
-    return z.enum([ 'GET', 'POST', 'PUT' ]);
-}
-
-export function zodSchemaWebhookAttributes() {
-    return z.object({
-        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
-        disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
-        secret_token: z.string().optional().nullable(),
-        url: z.string()
-    });
-}
-
-export function zodSchemaEmailAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaEndpointType() {
-    return z.enum([ 'webhook', 'email', 'default' ]);
-}
-
-export function zodSchemaEndpoint() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        enabled: z.boolean().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        properties: z
-        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
-        .optional()
-        .nullable(),
-        type: z.intersection(
-            zodSchemaEndpointType(),
-            z.enum([ 'webhook', 'email', 'default' ])
-        ),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaApplication() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        eventTypes: zodSchemaSetEventType().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaSetEndpoint() {
-    return z.array(zodSchemaEndpoint());
-}
-
-export function zodSchemaEventType() {
-    return z.object({
-        application: z
-        .lazy(() => zodSchemaApplication())
-        .optional()
-        .nullable(),
-        description: z.string(),
-        endpoints: zodSchemaSetEndpoint().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        name: z.string()
-    });
-}
-
-export function zodSchemaSetEventType() {
-    return z.array(zodSchemaEventType());
-}
-
-export function zodSchemaNotification() {
-    return z.object({
-        endpoint: zodSchemaEndpoint().optional().nullable(),
-        payload: z.unknown().optional().nullable(),
-        tenant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaJsonObject() {
-    return z.array(z.unknown());
-}
-
-export function zodSchemaNotificationHistory() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        details: zodSchemaJsonObject().optional().nullable(),
-        endpointId: zodSchemaUUID().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        invocationResult: z.boolean().optional().nullable(),
-        invocationTime: z.number().int().optional().nullable()
-    });
+    export type Payload =
+      | ValidatedResponse<'Response', 200, Schemas.Response>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/notifications/v1.0/notifications/{id}';
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -2252,582 +1967,559 @@ import * as z from 'zod';
 import { ValidateRule } from 'openapi2typescript';
 import { actionBuilder } from 'openapi2typescript/react-fetching-library';
 
-export const UUID = zodSchemaUUID();
+export namespace Schemas {
+  export const UUID = zodSchemaUUID();
 
-export const SetString = zodSchemaSetString();
+  export const SetString = zodSchemaSetString();
 
-export const NewCookie = zodSchemaNewCookie();
+  export const NewCookie = zodSchemaNewCookie();
 
-export const MapStringNewCookie = zodSchemaMapStringNewCookie();
+  export const MapStringNewCookie = zodSchemaMapStringNewCookie();
 
-export const Date = zodSchemaDate();
+  export const Date = zodSchemaDate();
 
-export const EntityTag = zodSchemaEntityTag();
+  export const EntityTag = zodSchemaEntityTag();
 
-export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
+  export const MultivaluedMapStringObject = zodSchemaMultivaluedMapStringObject();
 
-export const Locale = zodSchemaLocale();
+  export const Locale = zodSchemaLocale();
 
-export const Link = zodSchemaLink();
+  export const Link = zodSchemaLink();
 
-export const SetLink = zodSchemaSetLink();
+  export const SetLink = zodSchemaSetLink();
 
-export const URI = zodSchemaURI();
+  export const URI = zodSchemaURI();
 
-export const MediaType = zodSchemaMediaType();
+  export const MediaType = zodSchemaMediaType();
 
-export const StatusType = zodSchemaStatusType();
+  export const StatusType = zodSchemaStatusType();
 
-export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
+  export const MultivaluedMapStringString = zodSchemaMultivaluedMapStringString();
 
-export const Family = zodSchemaFamily();
+  export const Family = zodSchemaFamily();
 
-export const MapStringString = zodSchemaMapStringString();
+  export const MapStringString = zodSchemaMapStringString();
 
-export const ListString = zodSchemaListString();
+  export const ListString = zodSchemaListString();
 
-export const UriBuilder = zodSchemaUriBuilder();
+  export const UriBuilder = zodSchemaUriBuilder();
 
-export const SetCharacter = zodSchemaSetCharacter();
+  export const SetCharacter = zodSchemaSetCharacter();
 
-export const Response = zodSchemaResponse();
+  export const Response = zodSchemaResponse();
 
-export const Attributes = zodSchemaAttributes();
+  export const Attributes = zodSchemaAttributes();
 
-export const BasicAuthentication = zodSchemaBasicAuthentication();
+  export const BasicAuthentication = zodSchemaBasicAuthentication();
 
-export const HttpType = zodSchemaHttpType();
+  export const HttpType = zodSchemaHttpType();
 
-export const WebhookAttributes = zodSchemaWebhookAttributes();
+  export const WebhookAttributes = zodSchemaWebhookAttributes();
 
-export const EmailAttributes = zodSchemaEmailAttributes();
+  export const EmailAttributes = zodSchemaEmailAttributes();
 
-export const EndpointType = zodSchemaEndpointType();
+  export const EndpointType = zodSchemaEndpointType();
 
-export const Endpoint = zodSchemaEndpoint();
+  export const Endpoint = zodSchemaEndpoint();
 
-export const Application = zodSchemaApplication();
+  export const Application = zodSchemaApplication();
 
-export const SetEndpoint = zodSchemaSetEndpoint();
+  export const SetEndpoint = zodSchemaSetEndpoint();
 
-export const EventType = zodSchemaEventType();
+  export const EventType = zodSchemaEventType();
 
-export const SetEventType = zodSchemaSetEventType();
+  export const SetEventType = zodSchemaSetEventType();
 
-export const Notification = zodSchemaNotification();
+  export const Notification = zodSchemaNotification();
 
-export const JsonObject = zodSchemaJsonObject();
+  export const JsonObject = zodSchemaJsonObject();
 
-export const NotificationHistory = zodSchemaNotificationHistory();
+  export const NotificationHistory = zodSchemaNotificationHistory();
 
-// GET /notifications/defaults
-const NotificationServiceGetEndpointsForDefaultsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-export const actionNotificationServiceGetEndpointsForDefaults = () => {
-    const path = '/api/notifications/v1.0/notifications/defaults';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetEndpointsForDefaultsParamResponse200,
-                'NotificationServiceGetEndpointsForDefaultsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
+  function zodSchemaUUID() {
+      return z.string();
+  }
 
-// PUT /notifications/defaults/{endpointId}
-/*
+  function zodSchemaSetString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaNewCookie() {
+      return z.object({
+          domain: z.string().optional().nullable(),
+          name: z.string().optional().nullable(),
+          path: z.string().optional().nullable(),
+          value: z.string().optional().nullable(),
+          version: z.number().int().optional().nullable(),
+          comment: z.string().optional().nullable(),
+          expiry: zodSchemaDate().optional().nullable(),
+          httpOnly: z.boolean().optional().nullable(),
+          maxAge: z.number().int().optional().nullable(),
+          secure: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringNewCookie() {
+      return z.record(zodSchemaNewCookie());
+  }
+
+  function zodSchemaDate() {
+      return z.string();
+  }
+
+  function zodSchemaEntityTag() {
+      return z.object({
+          value: z.string().optional().nullable(),
+          weak: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringObject() {
+      return z.record(z.unknown());
+  }
+
+  function zodSchemaLocale() {
+      return z.object({
+          country: z.string().optional().nullable(),
+          displayCountry: z.string().optional().nullable(),
+          displayLanguage: z.string().optional().nullable(),
+          displayName: z.string().optional().nullable(),
+          displayScript: z.string().optional().nullable(),
+          displayVariant: z.string().optional().nullable(),
+          extensionKeys: zodSchemaSetCharacter().optional().nullable(),
+          iSO3Country: z.string().optional().nullable(),
+          iSO3Language: z.string().optional().nullable(),
+          language: z.string().optional().nullable(),
+          script: z.string().optional().nullable(),
+          unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
+          unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
+          variant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaLink() {
+      return z.object({
+          params: zodSchemaMapStringString().optional().nullable(),
+          rel: z.string().optional().nullable(),
+          rels: zodSchemaListString().optional().nullable(),
+          title: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          uri: zodSchemaURI().optional().nullable(),
+          uriBuilder: zodSchemaUriBuilder().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetLink() {
+      return z.array(zodSchemaLink());
+  }
+
+  function zodSchemaURI() {
+      return z.string();
+  }
+
+  function zodSchemaMediaType() {
+      return z.object({
+          parameters: zodSchemaMapStringString().optional().nullable(),
+          subtype: z.string().optional().nullable(),
+          type: z.string().optional().nullable(),
+          wildcardSubtype: z.boolean().optional().nullable(),
+          wildcardType: z.boolean().optional().nullable()
+      });
+  }
+
+  function zodSchemaStatusType() {
+      return z.object({
+          family: zodSchemaFamily().optional().nullable(),
+          reasonPhrase: z.string().optional().nullable(),
+          statusCode: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMultivaluedMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaFamily() {
+      return z.enum([
+          'CLIENT_ERROR',
+          'INFORMATIONAL',
+          'OTHER',
+          'REDIRECTION',
+          'SERVER_ERROR',
+          'SUCCESSFUL'
+      ]);
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaListString() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaUriBuilder() {
+      return z.unknown();
+  }
+
+  function zodSchemaSetCharacter() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaResponse() {
+      return z.object({
+          allowedMethods: zodSchemaSetString().optional().nullable(),
+          cookies: zodSchemaMapStringNewCookie().optional().nullable(),
+          date: zodSchemaDate().optional().nullable(),
+          entity: z.unknown().optional().nullable(),
+          entityTag: zodSchemaEntityTag().optional().nullable(),
+          headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          language: zodSchemaLocale().optional().nullable(),
+          lastModified: zodSchemaDate().optional().nullable(),
+          length: z.number().int().optional().nullable(),
+          links: zodSchemaSetLink().optional().nullable(),
+          location: zodSchemaURI().optional().nullable(),
+          mediaType: zodSchemaMediaType().optional().nullable(),
+          metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
+          status: z.number().int().optional().nullable(),
+          statusInfo: zodSchemaStatusType().optional().nullable(),
+          stringHeaders: zodSchemaMultivaluedMapStringString()
+          .optional()
+          .nullable()
+      });
+  }
+
+  function zodSchemaAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaBasicAuthentication() {
+      return z.object({
+          password: z.string().optional().nullable(),
+          username: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaHttpType() {
+      return z.enum([ 'GET', 'POST', 'PUT' ]);
+  }
+
+  function zodSchemaWebhookAttributes() {
+      return z.object({
+          basic_authentication: zodSchemaBasicAuthentication()
+          .optional()
+          .nullable(),
+          disable_ssl_verification: z.boolean().optional().nullable(),
+          method: z.intersection(
+              zodSchemaHttpType(),
+              z.enum([ 'GET', 'POST', 'PUT' ])
+          ),
+          secret_token: z.string().optional().nullable(),
+          url: z.string()
+      });
+  }
+
+  function zodSchemaEmailAttributes() {
+      return z.unknown();
+  }
+
+  function zodSchemaEndpointType() {
+      return z.enum([ 'webhook', 'email', 'default' ]);
+  }
+
+  function zodSchemaEndpoint() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          enabled: z.boolean().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          properties: z
+          .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
+          .optional()
+          .nullable(),
+          type: z.intersection(
+              zodSchemaEndpointType(),
+              z.enum([ 'webhook', 'email', 'default' ])
+          ),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaApplication() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          description: z.string(),
+          eventTypes: zodSchemaSetEventType().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          name: z.string(),
+          updated: zodSchemaDate().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetEndpoint() {
+      return z.array(zodSchemaEndpoint());
+  }
+
+  function zodSchemaEventType() {
+      return z.object({
+          application: z
+          .lazy(() => zodSchemaApplication())
+          .optional()
+          .nullable(),
+          description: z.string(),
+          endpoints: zodSchemaSetEndpoint().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaSetEventType() {
+      return z.array(zodSchemaEventType());
+  }
+
+  function zodSchemaNotification() {
+      return z.object({
+          endpoint: zodSchemaEndpoint().optional().nullable(),
+          payload: z.unknown().optional().nullable(),
+          tenant: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaJsonObject() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaNotificationHistory() {
+      return z.object({
+          created: zodSchemaDate().optional().nullable(),
+          details: zodSchemaJsonObject().optional().nullable(),
+          endpointId: zodSchemaUUID().optional().nullable(),
+          id: z.number().int().optional().nullable(),
+          invocationResult: z.boolean().optional().nullable(),
+          invocationTime: z.number().int().optional().nullable()
+      });
+  }
+}
+
+export namespace Operations {
+  // GET /notifications/defaults
+  export namespace NotificationServiceGetEndpointsForDefaults {
+    const Response200 = z.array(Schemas.Endpoint);
+    export const actionCreator = () => {
+        const path = '/api/notifications/v1.0/notifications/defaults';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /notifications/defaults/{endpointId}
+  export namespace NotificationServiceAddEndpointToDefaults {
+    /*
  Params
-'endpointId':UUID
+'endpointId':Schemas.UUID
 */
-export const actionNotificationServiceAddEndpointToDefaults = (params) => {
-    const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
-        '{endpointId}',
-        params.endpointId.toString()
-    );
-    const query = {};
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// DELETE /notifications/defaults/{endpointId}
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
+            '{endpointId}',
+            params.endpointId.toString()
+        );
+        const query = {};
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/defaults/{endpointId}
+  export namespace NotificationServiceDeleteEndpointFromDefaults {
+    /*
  Params
-'endpointId':UUID
+'endpointId':Schemas.UUID
 */
-export const actionNotificationServiceDeleteEndpointFromDefaults = (params) => {
-    const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
-        '{endpointId}',
-        params.endpointId.toString()
-    );
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// GET /notifications/eventTypes
-const NotificationServiceGetEventTypesParamLimit = z.number().int();
-const NotificationServiceGetEventTypesParamOffset = z.number().int();
-const NotificationServiceGetEventTypesParamPageNumber = z.number().int();
-const NotificationServiceGetEventTypesParamSortBy = z.string();
-const NotificationServiceGetEventTypesParamResponse200 = z.array(
-    zodSchemaEventType()
-);
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/defaults/{endpointId}'.replace(
+            '{endpointId}',
+            params.endpointId.toString()
+        );
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/eventTypes
+  export namespace NotificationServiceGetEventTypes {
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const PageNumber = z.number().int();
+    const SortBy = z.string();
+    const Response200 = z.array(Schemas.EventType);
+    /*
  Params
-'limit'?:NotificationServiceGetEventTypesParamLimit,
-'offset'?:NotificationServiceGetEventTypesParamOffset,
-'pageNumber'?:NotificationServiceGetEventTypesParamPageNumber,
-'sortBy'?:NotificationServiceGetEventTypesParamSortBy
+'limit'?:Limit,
+'offset'?:Offset,
+'pageNumber'?:PageNumber,
+'sortBy'?:SortBy
 */
-export const actionNotificationServiceGetEventTypes = (params) => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes';
-    const query = {};
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes';
+        const query = {};
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
-    }
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetEventTypesParamResponse200,
-                'NotificationServiceGetEventTypesParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /notifications/eventTypes/{eventTypeId}
-const NotificationServiceGetLinkedEndpointsParamEventTypeId = z.number().int();
-const NotificationServiceGetLinkedEndpointsParamLimit = z.number().int();
-const NotificationServiceGetLinkedEndpointsParamOffset = z.number().int();
-const NotificationServiceGetLinkedEndpointsParamPageNumber = z.number().int();
-const NotificationServiceGetLinkedEndpointsParamSortBy = z.string();
-const NotificationServiceGetLinkedEndpointsParamResponse200 = z.array(
-    zodSchemaEndpoint()
-);
-/*
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/eventTypes/{eventTypeId}
+  export namespace NotificationServiceGetLinkedEndpoints {
+    const EventTypeId = z.number().int();
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const PageNumber = z.number().int();
+    const SortBy = z.string();
+    const Response200 = z.array(Schemas.Endpoint);
+    /*
  Params
-'eventTypeId':NotificationServiceGetLinkedEndpointsParamEventTypeId,
-'limit'?:NotificationServiceGetLinkedEndpointsParamLimit,
-'offset'?:NotificationServiceGetLinkedEndpointsParamOffset,
-'pageNumber'?:NotificationServiceGetLinkedEndpointsParamPageNumber,
-'sortBy'?:NotificationServiceGetLinkedEndpointsParamSortBy
+'eventTypeId':EventTypeId,
+'limit'?:Limit,
+'offset'?:Offset,
+'pageNumber'?:PageNumber,
+'sortBy'?:SortBy
 */
-export const actionNotificationServiceGetLinkedEndpoints = (params) => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}'.replace(
-        '{eventTypeId}',
-        params.eventTypeId.toString()
-    );
-    const query = {};
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}'.replace(
+            '{eventTypeId}',
+            params.eventTypeId.toString()
+        );
+        const query = {};
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.pageNumber !== undefined) {
-        query.pageNumber = params.pageNumber.toString();
-    }
+        if (params.pageNumber !== undefined) {
+            query.pageNumber = params.pageNumber;
+        }
 
-    if (params.sortBy !== undefined) {
-        query.sort_by = params.sortBy.toString();
-    }
+        if (params.sortBy !== undefined) {
+            query.sort_by = params.sortBy;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetLinkedEndpointsParamResponse200,
-                'NotificationServiceGetLinkedEndpointsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// PUT /notifications/eventTypes/{eventTypeId}/{endpointId}
-const NotificationServiceLinkEndpointToEventTypeParamEventTypeId = z
-.number()
-.int();
-const NotificationServiceLinkEndpointToEventTypeParamResponse200 = z.string();
-/*
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // PUT /notifications/eventTypes/{eventTypeId}/{endpointId}
+  export namespace NotificationServiceLinkEndpointToEventType {
+    const EventTypeId = z.number().int();
+    const Response200 = z.string();
+    /*
  Params
-'endpointId':UUID,
-'eventTypeId':NotificationServiceLinkEndpointToEventTypeParamEventTypeId
+'endpointId':Schemas.UUID,
+'eventTypeId':EventTypeId
 */
-export const actionNotificationServiceLinkEndpointToEventType = (params) => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
-    .replace('{endpointId}', params.endpointId.toString())
-    .replace('{eventTypeId}', params.eventTypeId.toString());
-    const query = {};
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceLinkEndpointToEventTypeParamResponse200,
-                'NotificationServiceLinkEndpointToEventTypeParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /notifications/eventTypes/{eventTypeId}/{endpointId}
-const NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId = z
-.number()
-.int();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
+        .replace('{endpointId}', params.endpointId.toString())
+        .replace('{eventTypeId}', params.eventTypeId.toString());
+        const query = {};
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/eventTypes/{eventTypeId}/{endpointId}
+  export namespace NotificationServiceUnlinkEndpointFromEventType {
+    const EventTypeId = z.number().int();
+    /*
  Params
-'endpointId':UUID,
-'eventTypeId':NotificationServiceUnlinkEndpointFromEventTypeParamEventTypeId
+'endpointId':Schemas.UUID,
+'eventTypeId':EventTypeId
 */
-export const actionNotificationServiceUnlinkEndpointFromEventType = (
-    params
-) => {
-    const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
-    .replace('{endpointId}', params.endpointId.toString())
-    .replace('{eventTypeId}', params.eventTypeId.toString());
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-// GET /notifications/updates
-const NotificationServiceGetNotificationUpdatesParamResponse200 = z.array(
-    zodSchemaNotification()
-);
-export const actionNotificationServiceGetNotificationUpdates = () => {
-    const path = '/api/notifications/v1.0/notifications/updates';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                NotificationServiceGetNotificationUpdatesParamResponse200,
-                'NotificationServiceGetNotificationUpdatesParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// DELETE /notifications/{id}
-const NotificationServiceMarkReadParamBody = z.number().int();
-/*
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/eventTypes/{eventTypeId}/{endpointId}'
+        .replace('{endpointId}', params.endpointId.toString())
+        .replace('{eventTypeId}', params.eventTypeId.toString());
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /notifications/updates
+  export namespace NotificationServiceGetNotificationUpdates {
+    const Response200 = z.array(Schemas.Notification);
+    export const actionCreator = () => {
+        const path = '/api/notifications/v1.0/notifications/updates';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /notifications/{id}
+  export namespace NotificationServiceMarkRead {
+    const Body = z.number().int();
+    /*
  Params
-body: NotificationServiceMarkReadParamBody
+body: Body
 */
-export const actionNotificationServiceMarkRead = (params) => {
-    const path = '/api/notifications/v1.0/notifications/{id}';
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(Response, 'Response', 200) ]
-    })
-    .build();
-};
-
-export function zodSchemaUUID() {
-    return z.string();
-}
-
-export function zodSchemaSetString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaNewCookie() {
-    return z.object({
-        domain: z.string().optional().nullable(),
-        name: z.string().optional().nullable(),
-        path: z.string().optional().nullable(),
-        value: z.string().optional().nullable(),
-        version: z.number().int().optional().nullable(),
-        comment: z.string().optional().nullable(),
-        expiry: zodSchemaDate().optional().nullable(),
-        httpOnly: z.boolean().optional().nullable(),
-        maxAge: z.number().int().optional().nullable(),
-        secure: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMapStringNewCookie() {
-    return z.record(zodSchemaNewCookie());
-}
-
-export function zodSchemaDate() {
-    return z.string();
-}
-
-export function zodSchemaEntityTag() {
-    return z.object({
-        value: z.string().optional().nullable(),
-        weak: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringObject() {
-    return z.record(z.unknown());
-}
-
-export function zodSchemaLocale() {
-    return z.object({
-        country: z.string().optional().nullable(),
-        displayCountry: z.string().optional().nullable(),
-        displayLanguage: z.string().optional().nullable(),
-        displayName: z.string().optional().nullable(),
-        displayScript: z.string().optional().nullable(),
-        displayVariant: z.string().optional().nullable(),
-        extensionKeys: zodSchemaSetCharacter().optional().nullable(),
-        iSO3Country: z.string().optional().nullable(),
-        iSO3Language: z.string().optional().nullable(),
-        language: z.string().optional().nullable(),
-        script: z.string().optional().nullable(),
-        unicodeLocaleAttributes: zodSchemaSetString().optional().nullable(),
-        unicodeLocaleKeys: zodSchemaSetString().optional().nullable(),
-        variant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaLink() {
-    return z.object({
-        params: zodSchemaMapStringString().optional().nullable(),
-        rel: z.string().optional().nullable(),
-        rels: zodSchemaListString().optional().nullable(),
-        title: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        uri: zodSchemaURI().optional().nullable(),
-        uriBuilder: zodSchemaUriBuilder().optional().nullable()
-    });
-}
-
-export function zodSchemaSetLink() {
-    return z.array(zodSchemaLink());
-}
-
-export function zodSchemaURI() {
-    return z.string();
-}
-
-export function zodSchemaMediaType() {
-    return z.object({
-        parameters: zodSchemaMapStringString().optional().nullable(),
-        subtype: z.string().optional().nullable(),
-        type: z.string().optional().nullable(),
-        wildcardSubtype: z.boolean().optional().nullable(),
-        wildcardType: z.boolean().optional().nullable()
-    });
-}
-
-export function zodSchemaStatusType() {
-    return z.object({
-        family: zodSchemaFamily().optional().nullable(),
-        reasonPhrase: z.string().optional().nullable(),
-        statusCode: z.number().int().optional().nullable()
-    });
-}
-
-export function zodSchemaMultivaluedMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaFamily() {
-    return z.enum([
-        'CLIENT_ERROR',
-        'INFORMATIONAL',
-        'OTHER',
-        'REDIRECTION',
-        'SERVER_ERROR',
-        'SUCCESSFUL'
-    ]);
-}
-
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaListString() {
-    return z.array(z.string());
-}
-
-export function zodSchemaUriBuilder() {
-    return z.unknown();
-}
-
-export function zodSchemaSetCharacter() {
-    return z.array(z.string());
-}
-
-export function zodSchemaResponse() {
-    return z.object({
-        allowedMethods: zodSchemaSetString().optional().nullable(),
-        cookies: zodSchemaMapStringNewCookie().optional().nullable(),
-        date: zodSchemaDate().optional().nullable(),
-        entity: z.unknown().optional().nullable(),
-        entityTag: zodSchemaEntityTag().optional().nullable(),
-        headers: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        language: zodSchemaLocale().optional().nullable(),
-        lastModified: zodSchemaDate().optional().nullable(),
-        length: z.number().int().optional().nullable(),
-        links: zodSchemaSetLink().optional().nullable(),
-        location: zodSchemaURI().optional().nullable(),
-        mediaType: zodSchemaMediaType().optional().nullable(),
-        metadata: zodSchemaMultivaluedMapStringObject().optional().nullable(),
-        status: z.number().int().optional().nullable(),
-        statusInfo: zodSchemaStatusType().optional().nullable(),
-        stringHeaders: zodSchemaMultivaluedMapStringString().optional().nullable()
-    });
-}
-
-export function zodSchemaAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaBasicAuthentication() {
-    return z.object({
-        password: z.string().optional().nullable(),
-        username: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaHttpType() {
-    return z.enum([ 'GET', 'POST', 'PUT' ]);
-}
-
-export function zodSchemaWebhookAttributes() {
-    return z.object({
-        basic_authentication: zodSchemaBasicAuthentication().optional().nullable(),
-        disable_ssl_verification: z.boolean().optional().nullable(),
-        method: z.intersection(zodSchemaHttpType(), z.enum([ 'GET', 'POST', 'PUT' ])),
-        secret_token: z.string().optional().nullable(),
-        url: z.string()
-    });
-}
-
-export function zodSchemaEmailAttributes() {
-    return z.unknown();
-}
-
-export function zodSchemaEndpointType() {
-    return z.enum([ 'webhook', 'email', 'default' ]);
-}
-
-export function zodSchemaEndpoint() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        enabled: z.boolean().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        properties: z
-        .union([ zodSchemaWebhookAttributes(), zodSchemaEmailAttributes() ])
-        .optional()
-        .nullable(),
-        type: z.intersection(
-            zodSchemaEndpointType(),
-            z.enum([ 'webhook', 'email', 'default' ])
-        ),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaApplication() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        description: z.string(),
-        eventTypes: zodSchemaSetEventType().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        name: z.string(),
-        updated: zodSchemaDate().optional().nullable()
-    });
-}
-
-export function zodSchemaSetEndpoint() {
-    return z.array(zodSchemaEndpoint());
-}
-
-export function zodSchemaEventType() {
-    return z.object({
-        application: z
-        .lazy(() => zodSchemaApplication())
-        .optional()
-        .nullable(),
-        description: z.string(),
-        endpoints: zodSchemaSetEndpoint().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        name: z.string()
-    });
-}
-
-export function zodSchemaSetEventType() {
-    return z.array(zodSchemaEventType());
-}
-
-export function zodSchemaNotification() {
-    return z.object({
-        endpoint: zodSchemaEndpoint().optional().nullable(),
-        payload: z.unknown().optional().nullable(),
-        tenant: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaJsonObject() {
-    return z.array(z.unknown());
-}
-
-export function zodSchemaNotificationHistory() {
-    return z.object({
-        created: zodSchemaDate().optional().nullable(),
-        details: zodSchemaJsonObject().optional().nullable(),
-        endpointId: zodSchemaUUID().optional().nullable(),
-        id: z.number().int().optional().nullable(),
-        invocationResult: z.boolean().optional().nullable(),
-        invocationTime: z.number().int().optional().nullable()
-    });
+    export const actionCreator = (params) => {
+        const path = '/api/notifications/v1.0/notifications/{id}';
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.Response, 'Response', 200) ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -2846,944 +2538,787 @@ import {
     ActionValidatableConfig
 } from 'openapi2typescript/react-fetching-library';
 
-export const Policy = zodSchemaPolicy();
-export type Policy = z.infer<typeof Policy>;
+export namespace Schemas {
+  export const Policy = zodSchemaPolicy();
+  export type Policy = z.infer<typeof Policy>;
 
-export const Meta = zodSchemaMeta();
-export type Meta = z.infer<typeof Meta>;
+  export const Meta = zodSchemaMeta();
+  export type Meta = z.infer<typeof Meta>;
 
-export const MapStringString = zodSchemaMapStringString();
-export type MapStringString = z.infer<typeof MapStringString>;
+  export const MapStringString = zodSchemaMapStringString();
+  export type MapStringString = z.infer<typeof MapStringString>;
 
-export const HistoryItem = zodSchemaHistoryItem();
-export type HistoryItem = z.infer<typeof HistoryItem>;
+  export const HistoryItem = zodSchemaHistoryItem();
+  export type HistoryItem = z.infer<typeof HistoryItem>;
 
-export const Fact = zodSchemaFact();
-export type Fact = z.infer<typeof Fact>;
+  export const Fact = zodSchemaFact();
+  export type Fact = z.infer<typeof Fact>;
 
-export const PagedResponseOfHistoryItem = zodSchemaPagedResponseOfHistoryItem();
-export type PagedResponseOfHistoryItem = z.infer<
-  typeof PagedResponseOfHistoryItem
->;
+  export const PagedResponseOfHistoryItem = zodSchemaPagedResponseOfHistoryItem();
+  export type PagedResponseOfHistoryItem = z.infer<
+    typeof PagedResponseOfHistoryItem
+  >;
 
-export const FactType = zodSchemaFactType();
-export type FactType = z.infer<typeof FactType>;
+  export const FactType = zodSchemaFactType();
+  export type FactType = z.infer<typeof FactType>;
 
-export const ListUUID = zodSchemaListUUID();
-export type ListUUID = z.infer<typeof ListUUID>;
+  export const ListUUID = zodSchemaListUUID();
+  export type ListUUID = z.infer<typeof ListUUID>;
 
-export const PagedResponseOfPolicy = zodSchemaPagedResponseOfPolicy();
-export type PagedResponseOfPolicy = z.infer<typeof PagedResponseOfPolicy>;
+  export const PagedResponseOfPolicy = zodSchemaPagedResponseOfPolicy();
+  export type PagedResponseOfPolicy = z.infer<typeof PagedResponseOfPolicy>;
 
-export const List = zodSchemaList();
-export type List = z.infer<typeof List>;
+  export const List = zodSchemaList();
+  export type List = z.infer<typeof List>;
 
-export const ListPolicy = zodSchemaListPolicy();
-export type ListPolicy = z.infer<typeof ListPolicy>;
+  export const ListPolicy = zodSchemaListPolicy();
+  export type ListPolicy = z.infer<typeof ListPolicy>;
 
-export const UUID = zodSchemaUUID();
-export type UUID = z.infer<typeof UUID>;
+  export const UUID = zodSchemaUUID();
+  export type UUID = z.infer<typeof UUID>;
 
-export const ListHistoryItem = zodSchemaListHistoryItem();
-export type ListHistoryItem = z.infer<typeof ListHistoryItem>;
+  export const ListHistoryItem = zodSchemaListHistoryItem();
+  export type ListHistoryItem = z.infer<typeof ListHistoryItem>;
 
-export const __Empty = zodSchema__Empty();
-export type __Empty = z.infer<typeof __Empty>;
+  export const __Empty = zodSchema__Empty();
+  export type __Empty = z.infer<typeof __Empty>;
 
-// POST /policies/{id}/enabled
-// Enable/disable a policy
-const PostPoliciesByIdEnabledParamEnabled = z.boolean();
-type PostPoliciesByIdEnabledParamEnabled = z.infer<
-  typeof PostPoliciesByIdEnabledParamEnabled
->;
-export interface PostPoliciesByIdEnabled {
-  id: UUID;
-  enabled?: PostPoliciesByIdEnabledParamEnabled;
+  function zodSchemaPolicy() {
+      return z.object({
+          actions: z.string().optional().nullable(),
+          conditions: z.string(),
+          ctime: z.string().optional().nullable(),
+          description: z.string().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          isEnabled: z.boolean().optional().nullable(),
+          lastTriggered: z.number().int().optional().nullable(),
+          mtime: z.string().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaMeta() {
+      return z.object({
+          count: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaHistoryItem() {
+      return z.object({
+          ctime: z.number().int().optional().nullable(),
+          hostName: z.string().optional().nullable(),
+          id: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaFact() {
+      return z.object({
+          id: z.number().int().optional().nullable(),
+          name: z.string().optional().nullable(),
+          type: zodSchemaFactType().optional().nullable()
+      });
+  }
+
+  function zodSchemaPagedResponseOfHistoryItem() {
+      return z.object({
+          links: zodSchemaMapStringString().optional().nullable(),
+          meta: zodSchemaMeta().optional().nullable(),
+          data: zodSchemaListHistoryItem().optional().nullable()
+      });
+  }
+
+  function zodSchemaFactType() {
+      return z.enum([ 'BOOLEAN', 'INT', 'LIST', 'STRING' ]);
+  }
+
+  function zodSchemaListUUID() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaPagedResponseOfPolicy() {
+      return z.object({
+          links: zodSchemaMapStringString().optional().nullable(),
+          meta: zodSchemaMeta().optional().nullable(),
+          data: zodSchemaListPolicy().optional().nullable()
+      });
+  }
+
+  function zodSchemaList() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaListPolicy() {
+      return z.array(zodSchemaPolicy());
+  }
+
+  function zodSchemaUUID() {
+      return z.string();
+  }
+
+  function zodSchemaListHistoryItem() {
+      return z.array(zodSchemaHistoryItem());
+  }
+
+  function zodSchema__Empty() {
+      return z.string().max(0).optional();
+  }
 }
 
-export type PostPoliciesByIdEnabledPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'__Empty', 500, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostPoliciesByIdEnabled = Action<
-  PostPoliciesByIdEnabledPayload,
-  ActionValidatableConfig
->;
-export const actionPostPoliciesByIdEnabled = (
-    params: PostPoliciesByIdEnabled
-): ActionPostPoliciesByIdEnabled => {
-    const path = '/api/policies/v1.0/policies/{id}/enabled'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    if (params.enabled !== undefined) {
-        query.enabled = params.enabled.toString();
+export namespace Operations {
+  // POST /policies/{id}/enabled
+  // Enable/disable a policy
+  export namespace PostPoliciesByIdEnabled {
+    const Enabled = z.boolean();
+    type Enabled = z.infer<typeof Enabled>;
+    export interface Params {
+      id: Schemas.UUID;
+      enabled?: Enabled;
     }
 
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 500, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/{id}/enabled'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        if (params.enabled !== undefined) {
+            query.enabled = params.enabled;
+        }
 
-// GET /status
-export type GetStatusPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetStatus = Action<GetStatusPayload, ActionValidatableConfig>;
-export const actionGetStatus = (): ActionGetStatus => {
-    const path = '/api/policies/v1.0/status';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(__Empty, '__Empty', 200) ]
-    })
-    .build();
-};
-
-// POST /policies/ids/enabled
-// Enable/disable policies identified by list of uuid in body
-const PostPoliciesIdsEnabledParamEnabled = z.boolean();
-type PostPoliciesIdsEnabledParamEnabled = z.infer<
-  typeof PostPoliciesIdsEnabledParamEnabled
->;
-export interface PostPoliciesIdsEnabled {
-  enabled?: PostPoliciesIdsEnabledParamEnabled;
-  body: ListUUID;
-}
-
-export type PostPoliciesIdsEnabledPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostPoliciesIdsEnabled = Action<
-  PostPoliciesIdsEnabledPayload,
-  ActionValidatableConfig
->;
-export const actionPostPoliciesIdsEnabled = (
-    params: PostPoliciesIdsEnabled
-): ActionPostPoliciesIdsEnabled => {
-    const path = '/api/policies/v1.0/policies/ids/enabled';
-    const query = {} as Record<string, any>;
-    if (params.enabled !== undefined) {
-        query.enabled = params.enabled.toString();
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /status
+  export namespace GetStatus {
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/api/policies/v1.0/status';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.__Empty, '__Empty', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/ids/enabled
+  // Enable/disable policies identified by list of uuid in body
+  export namespace PostPoliciesIdsEnabled {
+    const Enabled = z.boolean();
+    type Enabled = z.infer<typeof Enabled>;
+    export interface Params {
+      enabled?: Enabled;
+      body: Schemas.ListUUID;
     }
 
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403)
-        ]
-    })
-    .build();
-};
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/ids/enabled';
+        const query = {} as Record<string, any>;
+        if (params.enabled !== undefined) {
+            query.enabled = params.enabled;
+        }
 
-// GET /facts
-// Retrieve a list of fact (keys) along with their data types
-const GetFactsParamResponse200 = z.array(zodSchemaFact());
-type GetFactsParamResponse200 = z.infer<typeof GetFactsParamResponse200>;
-export type GetFactsPayload =
-  | ValidatedResponse<'GetFactsParamResponse200', 200, GetFactsParamResponse200>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetFacts = Action<GetFactsPayload, ActionValidatableConfig>;
-export const actionGetFacts = (): ActionGetFacts => {
-    const path = '/api/policies/v1.0/facts';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                GetFactsParamResponse200,
-                'GetFactsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /policies
-// Return all policies for a given account
-const GetPoliciesParamFilterOpDescription = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-type GetPoliciesParamFilterOpDescription = z.infer<
-  typeof GetPoliciesParamFilterOpDescription
->;
-const GetPoliciesParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-type GetPoliciesParamFilterOpName = z.infer<
-  typeof GetPoliciesParamFilterOpName
->;
-const GetPoliciesParamFilterDescription = z.string();
-type GetPoliciesParamFilterDescription = z.infer<
-  typeof GetPoliciesParamFilterDescription
->;
-const GetPoliciesParamFilterIsEnabled = z.enum([ 'true', 'false' ]);
-type GetPoliciesParamFilterIsEnabled = z.infer<
-  typeof GetPoliciesParamFilterIsEnabled
->;
-const GetPoliciesParamFilterName = z.string();
-type GetPoliciesParamFilterName = z.infer<typeof GetPoliciesParamFilterName>;
-const GetPoliciesParamLimit = z.number().int();
-type GetPoliciesParamLimit = z.infer<typeof GetPoliciesParamLimit>;
-const GetPoliciesParamOffset = z.number().int();
-type GetPoliciesParamOffset = z.infer<typeof GetPoliciesParamOffset>;
-const GetPoliciesParamSortColumn = z.enum([
-    'name',
-    'description',
-    'is_enabled',
-    'mtime'
-]);
-type GetPoliciesParamSortColumn = z.infer<typeof GetPoliciesParamSortColumn>;
-const GetPoliciesParamSortDirection = z.enum([ 'asc', 'desc' ]);
-type GetPoliciesParamSortDirection = z.infer<
-  typeof GetPoliciesParamSortDirection
->;
-export interface GetPolicies {
-  filterOpDescription?: GetPoliciesParamFilterOpDescription;
-  filterOpName?: GetPoliciesParamFilterOpName;
-  filterDescription?: GetPoliciesParamFilterDescription;
-  filterIsEnabled?: GetPoliciesParamFilterIsEnabled;
-  filterName?: GetPoliciesParamFilterName;
-  limit?: GetPoliciesParamLimit;
-  offset?: GetPoliciesParamOffset;
-  sortColumn?: GetPoliciesParamSortColumn;
-  sortDirection?: GetPoliciesParamSortDirection;
-}
-
-export type GetPoliciesPayload =
-  | ValidatedResponse<'PagedResponseOfPolicy', 200, PagedResponseOfPolicy>
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetPolicies = Action<
-  GetPoliciesPayload,
-  ActionValidatableConfig
->;
-export const actionGetPolicies = (params: GetPolicies): ActionGetPolicies => {
-    const path = '/api/policies/v1.0/policies';
-    const query = {} as Record<string, any>;
-    if (params.filterOpDescription !== undefined) {
-        query['filter:op[description]'] = params.filterOpDescription.toString();
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /facts
+  // Retrieve a list of fact (keys) along with their data types
+  export namespace GetFacts {
+    const Response200 = z.array(Schemas.Fact);
+    type Response200 = z.infer<typeof Response200>;
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/api/policies/v1.0/facts';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /policies
+  // Return all policies for a given account
+  export namespace GetPolicies {
+    const FilterOpDescription = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    type FilterOpDescription = z.infer<typeof FilterOpDescription>;
+    const FilterOpName = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    type FilterOpName = z.infer<typeof FilterOpName>;
+    const FilterDescription = z.string();
+    type FilterDescription = z.infer<typeof FilterDescription>;
+    const FilterIsEnabled = z.enum([ 'true', 'false' ]);
+    type FilterIsEnabled = z.infer<typeof FilterIsEnabled>;
+    const FilterName = z.string();
+    type FilterName = z.infer<typeof FilterName>;
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const SortColumn = z.enum([ 'name', 'description', 'is_enabled', 'mtime' ]);
+    type SortColumn = z.infer<typeof SortColumn>;
+    const SortDirection = z.enum([ 'asc', 'desc' ]);
+    type SortDirection = z.infer<typeof SortDirection>;
+    export interface Params {
+      filterOpDescription?: FilterOpDescription;
+      filterOpName?: FilterOpName;
+      filterDescription?: FilterDescription;
+      filterIsEnabled?: FilterIsEnabled;
+      filterName?: FilterName;
+      limit?: Limit;
+      offset?: Offset;
+      sortColumn?: SortColumn;
+      sortDirection?: SortDirection;
     }
 
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
+    export type Payload =
+      | ValidatedResponse<
+          'PagedResponseOfPolicy',
+          200,
+          Schemas.PagedResponseOfPolicy
+        >
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies';
+        const query = {} as Record<string, any>;
+        if (params.filterOpDescription !== undefined) {
+            query['filter:op[description]'] = params.filterOpDescription;
+        }
 
-    if (params.filterDescription !== undefined) {
-        query['filter[description]'] = params.filterDescription.toString();
-    }
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
 
-    if (params.filterIsEnabled !== undefined) {
-        query['filter[is_enabled]'] = params.filterIsEnabled.toString();
-    }
+        if (params.filterDescription !== undefined) {
+            query['filter[description]'] = params.filterDescription;
+        }
 
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
+        if (params.filterIsEnabled !== undefined) {
+            query['filter[is_enabled]'] = params.filterIsEnabled;
+        }
 
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.sortColumn !== undefined) {
-        query.sortColumn = params.sortColumn.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.sortDirection !== undefined) {
-        query.sortDirection = params.sortDirection.toString();
-    }
+        if (params.sortColumn !== undefined) {
+            query.sortColumn = params.sortColumn;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(PagedResponseOfPolicy, 'PagedResponseOfPolicy', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
+        if (params.sortDirection !== undefined) {
+            query.sortDirection = params.sortDirection;
+        }
 
-// POST /policies
-// Validate (and possibly persist) a passed policy for the given account
-const PostPoliciesParamAlsoStore = z.boolean();
-type PostPoliciesParamAlsoStore = z.infer<typeof PostPoliciesParamAlsoStore>;
-const PostPoliciesParamResponse400 = z.object({
-    msg: z.string().optional().nullable()
-});
-type PostPoliciesParamResponse400 = z.infer<
-  typeof PostPoliciesParamResponse400
->;
-const PostPoliciesParamResponse409 = z.object({
-    msg: z.string().optional().nullable()
-});
-type PostPoliciesParamResponse409 = z.infer<
-  typeof PostPoliciesParamResponse409
->;
-export interface PostPolicies {
-  alsoStore?: PostPoliciesParamAlsoStore;
-  body: Policy;
-}
-
-export type PostPoliciesPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'Policy', 201, Policy>
-  | ValidatedResponse<
-      'PostPoliciesParamResponse400',
-      400,
-      PostPoliciesParamResponse400
-    >
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<
-      'PostPoliciesParamResponse409',
-      409,
-      PostPoliciesParamResponse409
-    >
-  | ValidatedResponse<'__Empty', 500, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostPolicies = Action<
-  PostPoliciesPayload,
-  ActionValidatableConfig
->;
-export const actionPostPolicies = (
-    params: PostPolicies
-): ActionPostPolicies => {
-    const path = '/api/policies/v1.0/policies';
-    const query = {} as Record<string, any>;
-    if (params.alsoStore !== undefined) {
-        query.alsoStore = params.alsoStore.toString();
-    }
-
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(Policy, 'Policy', 201),
-            new ValidateRule(
-                PostPoliciesParamResponse400,
-                'PostPoliciesParamResponse400',
-                400
-            ),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(
-                PostPoliciesParamResponse409,
-                'PostPoliciesParamResponse409',
-                409
-            ),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /policies/{id}
-// Retrieve a single policy for a customer by its id
-export interface GetPoliciesById {
-  id: UUID;
-}
-
-export type GetPoliciesByIdPayload =
-  | ValidatedResponse<'Policy', 200, Policy>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetPoliciesById = Action<
-  GetPoliciesByIdPayload,
-  ActionValidatableConfig
->;
-export const actionGetPoliciesById = (
-    params: GetPoliciesById
-): ActionGetPoliciesById => {
-    const path = '/api/policies/v1.0/policies/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(Policy, 'Policy', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// DELETE /policies/{id}
-// Delete a single policy for a customer by its id
-export interface DeletePoliciesById {
-  id: UUID;
-}
-
-export type DeletePoliciesByIdPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionDeletePoliciesById = Action<
-  DeletePoliciesByIdPayload,
-  ActionValidatableConfig
->;
-export const actionDeletePoliciesById = (
-    params: DeletePoliciesById
-): ActionDeletePoliciesById => {
-    const path = '/api/policies/v1.0/policies/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// PUT /policies/{policyId}
-// Update a single policy for a customer by its id
-const PutPoliciesByPolicyIdParamDry = z.boolean();
-type PutPoliciesByPolicyIdParamDry = z.infer<
-  typeof PutPoliciesByPolicyIdParamDry
->;
-const PutPoliciesByPolicyIdParamResponse409 = z.object({
-    msg: z.string().optional().nullable()
-});
-type PutPoliciesByPolicyIdParamResponse409 = z.infer<
-  typeof PutPoliciesByPolicyIdParamResponse409
->;
-export interface PutPoliciesByPolicyId {
-  policyId: UUID;
-  dry?: PutPoliciesByPolicyIdParamDry;
-  body: Policy;
-}
-
-export type PutPoliciesByPolicyIdPayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<
-      'PutPoliciesByPolicyIdParamResponse409',
-      409,
-      PutPoliciesByPolicyIdParamResponse409
-    >
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPutPoliciesByPolicyId = Action<
-  PutPoliciesByPolicyIdPayload,
-  ActionValidatableConfig
->;
-export const actionPutPoliciesByPolicyId = (
-    params: PutPoliciesByPolicyId
-): ActionPutPoliciesByPolicyId => {
-    const path = '/api/policies/v1.0/policies/{policyId}'.replace(
-        '{policyId}',
-        params.policyId.toString()
-    );
-    const query = {} as Record<string, any>;
-    if (params.dry !== undefined) {
-        query.dry = params.dry.toString();
-    }
-
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(
-                PutPoliciesByPolicyIdParamResponse409,
-                'PutPoliciesByPolicyIdParamResponse409',
-                409
-            )
-        ]
-    })
-    .build();
-};
-
-// POST /policies/validate-name
-// Validates the Policy.name and verifies if it is unique.
-const PostPoliciesValidateNameParamBody = z.string();
-type PostPoliciesValidateNameParamBody = z.infer<
-  typeof PostPoliciesValidateNameParamBody
->;
-export interface PostPoliciesValidateName {
-  id?: UUID;
-  body: PostPoliciesValidateNameParamBody;
-}
-
-export type PostPoliciesValidateNamePayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 409, __Empty>
-  | ValidatedResponse<'__Empty', 500, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostPoliciesValidateName = Action<
-  PostPoliciesValidateNamePayload,
-  ActionValidatableConfig
->;
-export const actionPostPoliciesValidateName = (
-    params: PostPoliciesValidateName
-): ActionPostPoliciesValidateName => {
-    const path = '/api/policies/v1.0/policies/validate-name';
-    const query = {} as Record<string, any>;
-    if (params.id !== undefined) {
-        query.id = params.id.toString();
-    }
-
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 409),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /policies/ids
-// Return all policy ids for a given account after applying the filters
-const GetPoliciesIdsParamFilterOpDescription = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-type GetPoliciesIdsParamFilterOpDescription = z.infer<
-  typeof GetPoliciesIdsParamFilterOpDescription
->;
-const GetPoliciesIdsParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-type GetPoliciesIdsParamFilterOpName = z.infer<
-  typeof GetPoliciesIdsParamFilterOpName
->;
-const GetPoliciesIdsParamFilterDescription = z.string();
-type GetPoliciesIdsParamFilterDescription = z.infer<
-  typeof GetPoliciesIdsParamFilterDescription
->;
-const GetPoliciesIdsParamFilterIsEnabled = z.enum([ 'true', 'false' ]);
-type GetPoliciesIdsParamFilterIsEnabled = z.infer<
-  typeof GetPoliciesIdsParamFilterIsEnabled
->;
-const GetPoliciesIdsParamFilterName = z.string();
-type GetPoliciesIdsParamFilterName = z.infer<
-  typeof GetPoliciesIdsParamFilterName
->;
-export interface GetPoliciesIds {
-  filterOpDescription?: GetPoliciesIdsParamFilterOpDescription;
-  filterOpName?: GetPoliciesIdsParamFilterOpName;
-  filterDescription?: GetPoliciesIdsParamFilterDescription;
-  filterIsEnabled?: GetPoliciesIdsParamFilterIsEnabled;
-  filterName?: GetPoliciesIdsParamFilterName;
-}
-
-export type GetPoliciesIdsPayload =
-  | ValidatedResponse<'List', 200, List>
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetPoliciesIds = Action<
-  GetPoliciesIdsPayload,
-  ActionValidatableConfig
->;
-export const actionGetPoliciesIds = (
-    params: GetPoliciesIds
-): ActionGetPoliciesIds => {
-    const path = '/api/policies/v1.0/policies/ids';
-    const query = {} as Record<string, any>;
-    if (params.filterOpDescription !== undefined) {
-        query['filter:op[description]'] = params.filterOpDescription.toString();
-    }
-
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
-
-    if (params.filterDescription !== undefined) {
-        query['filter[description]'] = params.filterDescription.toString();
-    }
-
-    if (params.filterIsEnabled !== undefined) {
-        query['filter[is_enabled]'] = params.filterIsEnabled.toString();
-    }
-
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(List, 'List', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// DELETE /policies/ids
-// Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
-const DeletePoliciesIdsParamResponse200 = z.array(zodSchemaUUID());
-type DeletePoliciesIdsParamResponse200 = z.infer<
-  typeof DeletePoliciesIdsParamResponse200
->;
-export interface DeletePoliciesIds {
-  body: ListUUID;
-}
-
-export type DeletePoliciesIdsPayload =
-  | ValidatedResponse<
-      'DeletePoliciesIdsParamResponse200',
-      200,
-      DeletePoliciesIdsParamResponse200
-    >
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionDeletePoliciesIds = Action<
-  DeletePoliciesIdsPayload,
-  ActionValidatableConfig
->;
-export const actionDeletePoliciesIds = (
-    params: DeletePoliciesIds
-): ActionDeletePoliciesIds => {
-    const path = '/api/policies/v1.0/policies/ids';
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(
-                DeletePoliciesIdsParamResponse200,
-                'DeletePoliciesIdsParamResponse200',
-                200
-            ),
-            new ValidateRule(__Empty, '__Empty', 403)
-        ]
-    })
-    .build();
-};
-
-// POST /policies/validate
-// Validates a Policy condition
-export interface PostPoliciesValidate {
-  body: Policy;
-}
-
-export type PostPoliciesValidatePayload =
-  | ValidatedResponse<'__Empty', 200, __Empty>
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 500, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostPoliciesValidate = Action<
-  PostPoliciesValidatePayload,
-  ActionValidatableConfig
->;
-export const actionPostPoliciesValidate = (
-    params: PostPoliciesValidate
-): ActionPostPoliciesValidate => {
-    const path = '/api/policies/v1.0/policies/validate';
-    const query = {} as Record<string, any>;
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /
-// Just a filler to have a defined return code for the base path
-export type GetPayload =
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGet = Action<GetPayload, ActionValidatableConfig>;
-export const actionGet = (): ActionGet => {
-    const path = '/api/policies/v1.0/';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(__Empty, '__Empty', 404) ]
-    })
-    .build();
-};
-
-// GET /policies/{id}/history/trigger
-// Retrieve the trigger history of a single policy
-const GetPoliciesByIdHistoryTriggerParamFilterOpId = z.enum([
-    'equal',
-    'not_equal',
-    'like'
-]);
-type GetPoliciesByIdHistoryTriggerParamFilterOpId = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamFilterOpId
->;
-const GetPoliciesByIdHistoryTriggerParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'not_equal'
-]);
-type GetPoliciesByIdHistoryTriggerParamFilterOpName = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamFilterOpName
->;
-const GetPoliciesByIdHistoryTriggerParamFilterId = z.string();
-type GetPoliciesByIdHistoryTriggerParamFilterId = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamFilterId
->;
-const GetPoliciesByIdHistoryTriggerParamFilterName = z.string();
-type GetPoliciesByIdHistoryTriggerParamFilterName = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamFilterName
->;
-const GetPoliciesByIdHistoryTriggerParamLimit = z.number().int();
-type GetPoliciesByIdHistoryTriggerParamLimit = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamLimit
->;
-const GetPoliciesByIdHistoryTriggerParamOffset = z.number().int();
-type GetPoliciesByIdHistoryTriggerParamOffset = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamOffset
->;
-const GetPoliciesByIdHistoryTriggerParamSortColumn = z.enum([
-    'hostName',
-    'id',
-    'ctime'
-]);
-type GetPoliciesByIdHistoryTriggerParamSortColumn = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamSortColumn
->;
-const GetPoliciesByIdHistoryTriggerParamSortDirection = z.enum([ 'asc', 'desc' ]);
-type GetPoliciesByIdHistoryTriggerParamSortDirection = z.infer<
-  typeof GetPoliciesByIdHistoryTriggerParamSortDirection
->;
-export interface GetPoliciesByIdHistoryTrigger {
-  id: UUID;
-  filterOpId?: GetPoliciesByIdHistoryTriggerParamFilterOpId;
-  filterOpName?: GetPoliciesByIdHistoryTriggerParamFilterOpName;
-  filterId?: GetPoliciesByIdHistoryTriggerParamFilterId;
-  filterName?: GetPoliciesByIdHistoryTriggerParamFilterName;
-  limit?: GetPoliciesByIdHistoryTriggerParamLimit;
-  offset?: GetPoliciesByIdHistoryTriggerParamOffset;
-  sortColumn?: GetPoliciesByIdHistoryTriggerParamSortColumn;
-  sortDirection?: GetPoliciesByIdHistoryTriggerParamSortDirection;
-}
-
-export type GetPoliciesByIdHistoryTriggerPayload =
-  | ValidatedResponse<
-      'PagedResponseOfHistoryItem',
-      200,
-      PagedResponseOfHistoryItem
-    >
-  | ValidatedResponse<'__Empty', 400, __Empty>
-  | ValidatedResponse<'__Empty', 403, __Empty>
-  | ValidatedResponse<'__Empty', 404, __Empty>
-  | ValidatedResponse<'__Empty', 500, __Empty>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetPoliciesByIdHistoryTrigger = Action<
-  GetPoliciesByIdHistoryTriggerPayload,
-  ActionValidatableConfig
->;
-export const actionGetPoliciesByIdHistoryTrigger = (
-    params: GetPoliciesByIdHistoryTrigger
-): ActionGetPoliciesByIdHistoryTrigger => {
-    const path = '/api/policies/v1.0/policies/{id}/history/trigger'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {} as Record<string, any>;
-    if (params.filterOpId !== undefined) {
-        query['filter:op[id]'] = params.filterOpId.toString();
-    }
-
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
-
-    if (params.filterId !== undefined) {
-        query['filter[id]'] = params.filterId.toString();
-    }
-
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
-
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
-
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
-
-    if (params.sortColumn !== undefined) {
-        query.sortColumn = params.sortColumn.toString();
-    }
-
-    if (params.sortDirection !== undefined) {
-        query.sortDirection = params.sortDirection.toString();
-    }
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                PagedResponseOfHistoryItem,
-                'PagedResponseOfHistoryItem',
-                200
-            ),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-export function zodSchemaPolicy() {
-    return z.object({
-        actions: z.string().optional().nullable(),
-        conditions: z.string(),
-        ctime: z.string().optional().nullable(),
-        description: z.string().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        isEnabled: z.boolean().optional().nullable(),
-        lastTriggered: z.number().int().optional().nullable(),
-        mtime: z.string().optional().nullable(),
-        name: z.string()
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(
+                    Schemas.PagedResponseOfPolicy,
+                    'PagedResponseOfPolicy',
+                    200
+                ),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies
+  // Validate (and possibly persist) a passed policy for the given account
+  export namespace PostPolicies {
+    const AlsoStore = z.boolean();
+    type AlsoStore = z.infer<typeof AlsoStore>;
+    const Response400 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
-
-export function zodSchemaMeta() {
-    return z.object({
-        count: z.number().int().optional().nullable()
+    type Response400 = z.infer<typeof Response400>;
+    const Response409 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
+    type Response409 = z.infer<typeof Response409>;
+    export interface Params {
+      alsoStore?: AlsoStore;
+      body: Schemas.Policy;
+    }
 
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'Policy', 201, Schemas.Policy>
+      | ValidatedResponse<'Response400', 400, Response400>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'Response409', 409, Response409>
+      | ValidatedResponse<'__Empty', 500, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies';
+        const query = {} as Record<string, any>;
+        if (params.alsoStore !== undefined) {
+            query.alsoStore = params.alsoStore;
+        }
 
-export function zodSchemaHistoryItem() {
-    return z.object({
-        ctime: z.number().int().optional().nullable(),
-        hostName: z.string().optional().nullable(),
-        id: z.string().optional().nullable()
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.Policy, 'Policy', 201),
+                new ValidateRule(Response400, 'Response400', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Response409, 'Response409', 409),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/{id}
+  // Retrieve a single policy for a customer by its id
+  export namespace GetPoliciesById {
+    export interface Params {
+      id: Schemas.UUID;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'Policy', 200, Schemas.Policy>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.Policy, 'Policy', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // DELETE /policies/{id}
+  // Delete a single policy for a customer by its id
+  export namespace DeletePoliciesById {
+    export interface Params {
+      id: Schemas.UUID;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // PUT /policies/{policyId}
+  // Update a single policy for a customer by its id
+  export namespace PutPoliciesByPolicyId {
+    const Dry = z.boolean();
+    type Dry = z.infer<typeof Dry>;
+    const Response409 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
+    type Response409 = z.infer<typeof Response409>;
+    export interface Params {
+      policyId: Schemas.UUID;
+      dry?: Dry;
+      body: Schemas.Policy;
+    }
 
-export function zodSchemaFact() {
-    return z.object({
-        id: z.number().int().optional().nullable(),
-        name: z.string().optional().nullable(),
-        type: zodSchemaFactType().optional().nullable()
-    });
-}
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'Response409', 409, Response409>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/{policyId}'.replace(
+            '{policyId}',
+            params.policyId.toString()
+        );
+        const query = {} as Record<string, any>;
+        if (params.dry !== undefined) {
+            query.dry = params.dry;
+        }
 
-export function zodSchemaPagedResponseOfHistoryItem() {
-    return z.object({
-        links: zodSchemaMapStringString().optional().nullable(),
-        meta: zodSchemaMeta().optional().nullable(),
-        data: zodSchemaListHistoryItem().optional().nullable()
-    });
-}
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Response409, 'Response409', 409)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/validate-name
+  // Validates the Policy.name and verifies if it is unique.
+  export namespace PostPoliciesValidateName {
+    const Body = z.string();
+    type Body = z.infer<typeof Body>;
+    export interface Params {
+      id?: Schemas.UUID;
+      body: Body;
+    }
 
-export function zodSchemaFactType() {
-    return z.enum([ 'BOOLEAN', 'INT', 'LIST', 'STRING' ]);
-}
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 409, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 500, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/validate-name';
+        const query = {} as Record<string, any>;
+        if (params.id !== undefined) {
+            query.id = params.id;
+        }
 
-export function zodSchemaListUUID() {
-    return z.array(z.string());
-}
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 409),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/ids
+  // Return all policy ids for a given account after applying the filters
+  export namespace GetPoliciesIds {
+    const FilterOpDescription = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    type FilterOpDescription = z.infer<typeof FilterOpDescription>;
+    const FilterOpName = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    type FilterOpName = z.infer<typeof FilterOpName>;
+    const FilterDescription = z.string();
+    type FilterDescription = z.infer<typeof FilterDescription>;
+    const FilterIsEnabled = z.enum([ 'true', 'false' ]);
+    type FilterIsEnabled = z.infer<typeof FilterIsEnabled>;
+    const FilterName = z.string();
+    type FilterName = z.infer<typeof FilterName>;
+    export interface Params {
+      filterOpDescription?: FilterOpDescription;
+      filterOpName?: FilterOpName;
+      filterDescription?: FilterDescription;
+      filterIsEnabled?: FilterIsEnabled;
+      filterName?: FilterName;
+    }
 
-export function zodSchemaPagedResponseOfPolicy() {
-    return z.object({
-        links: zodSchemaMapStringString().optional().nullable(),
-        meta: zodSchemaMeta().optional().nullable(),
-        data: zodSchemaListPolicy().optional().nullable()
-    });
-}
+    export type Payload =
+      | ValidatedResponse<'List', 200, Schemas.List>
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/ids';
+        const query = {} as Record<string, any>;
+        if (params.filterOpDescription !== undefined) {
+            query['filter:op[description]'] = params.filterOpDescription;
+        }
 
-export function zodSchemaList() {
-    return z.array(z.unknown());
-}
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
 
-export function zodSchemaListPolicy() {
-    return z.array(zodSchemaPolicy());
-}
+        if (params.filterDescription !== undefined) {
+            query['filter[description]'] = params.filterDescription;
+        }
 
-export function zodSchemaUUID() {
-    return z.string();
-}
+        if (params.filterIsEnabled !== undefined) {
+            query['filter[is_enabled]'] = params.filterIsEnabled;
+        }
 
-export function zodSchemaListHistoryItem() {
-    return z.array(zodSchemaHistoryItem());
-}
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
 
-export function zodSchema__Empty() {
-    return z.string().max(0).optional();
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.List, 'List', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // DELETE /policies/ids
+  // Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
+  export namespace DeletePoliciesIds {
+    const Response200 = z.array(Schemas.UUID);
+    type Response200 = z.infer<typeof Response200>;
+    export interface Params {
+      body: Schemas.ListUUID;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'Response200', 200, Response200>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/ids';
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Response200, 'Response200', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/validate
+  // Validates a Policy condition
+  export namespace PostPoliciesValidate {
+    export interface Params {
+      body: Schemas.Policy;
+    }
+
+    export type Payload =
+      | ValidatedResponse<'__Empty', 200, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 500, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/validate';
+        const query = {} as Record<string, any>;
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /
+  // Just a filler to have a defined return code for the base path
+  export namespace Get {
+    export type Payload =
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/api/policies/v1.0/';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.__Empty, '__Empty', 404) ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/{id}/history/trigger
+  // Retrieve the trigger history of a single policy
+  export namespace GetPoliciesByIdHistoryTrigger {
+    const FilterOpId = z.enum([ 'equal', 'not_equal', 'like' ]);
+    type FilterOpId = z.infer<typeof FilterOpId>;
+    const FilterOpName = z.enum([ 'equal', 'like', 'not_equal' ]);
+    type FilterOpName = z.infer<typeof FilterOpName>;
+    const FilterId = z.string();
+    type FilterId = z.infer<typeof FilterId>;
+    const FilterName = z.string();
+    type FilterName = z.infer<typeof FilterName>;
+    const Limit = z.number().int();
+    type Limit = z.infer<typeof Limit>;
+    const Offset = z.number().int();
+    type Offset = z.infer<typeof Offset>;
+    const SortColumn = z.enum([ 'hostName', 'id', 'ctime' ]);
+    type SortColumn = z.infer<typeof SortColumn>;
+    const SortDirection = z.enum([ 'asc', 'desc' ]);
+    type SortDirection = z.infer<typeof SortDirection>;
+    export interface Params {
+      id: Schemas.UUID;
+      filterOpId?: FilterOpId;
+      filterOpName?: FilterOpName;
+      filterId?: FilterId;
+      filterName?: FilterName;
+      limit?: Limit;
+      offset?: Offset;
+      sortColumn?: SortColumn;
+      sortDirection?: SortDirection;
+    }
+
+    export type Payload =
+      | ValidatedResponse<
+          'PagedResponseOfHistoryItem',
+          200,
+          Schemas.PagedResponseOfHistoryItem
+        >
+      | ValidatedResponse<'__Empty', 400, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 403, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 404, Schemas.__Empty>
+      | ValidatedResponse<'__Empty', 500, Schemas.__Empty>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/api/policies/v1.0/policies/{id}/history/trigger'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {} as Record<string, any>;
+        if (params.filterOpId !== undefined) {
+            query['filter:op[id]'] = params.filterOpId;
+        }
+
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
+
+        if (params.filterId !== undefined) {
+            query['filter[id]'] = params.filterId;
+        }
+
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
+
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
+
+        if (params.sortColumn !== undefined) {
+            query.sortColumn = params.sortColumn;
+        }
+
+        if (params.sortDirection !== undefined) {
+            query.sortDirection = params.sortDirection;
+        }
+
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(
+                    Schemas.PagedResponseOfHistoryItem,
+                    'PagedResponseOfHistoryItem',
+                    200
+                ),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -3797,672 +3332,637 @@ import * as z from 'zod';
 import { ValidateRule } from 'openapi2typescript';
 import { actionBuilder } from 'openapi2typescript/react-fetching-library';
 
-export const Policy = zodSchemaPolicy();
+export namespace Schemas {
+  export const Policy = zodSchemaPolicy();
 
-export const Meta = zodSchemaMeta();
+  export const Meta = zodSchemaMeta();
 
-export const MapStringString = zodSchemaMapStringString();
+  export const MapStringString = zodSchemaMapStringString();
 
-export const HistoryItem = zodSchemaHistoryItem();
+  export const HistoryItem = zodSchemaHistoryItem();
 
-export const Fact = zodSchemaFact();
+  export const Fact = zodSchemaFact();
 
-export const PagedResponseOfHistoryItem = zodSchemaPagedResponseOfHistoryItem();
+  export const PagedResponseOfHistoryItem = zodSchemaPagedResponseOfHistoryItem();
 
-export const FactType = zodSchemaFactType();
+  export const FactType = zodSchemaFactType();
 
-export const ListUUID = zodSchemaListUUID();
+  export const ListUUID = zodSchemaListUUID();
 
-export const PagedResponseOfPolicy = zodSchemaPagedResponseOfPolicy();
+  export const PagedResponseOfPolicy = zodSchemaPagedResponseOfPolicy();
 
-export const List = zodSchemaList();
+  export const List = zodSchemaList();
 
-export const ListPolicy = zodSchemaListPolicy();
+  export const ListPolicy = zodSchemaListPolicy();
 
-export const UUID = zodSchemaUUID();
+  export const UUID = zodSchemaUUID();
 
-export const ListHistoryItem = zodSchemaListHistoryItem();
+  export const ListHistoryItem = zodSchemaListHistoryItem();
 
-export const __Empty = zodSchema__Empty();
+  export const __Empty = zodSchema__Empty();
 
-// POST /policies/{id}/enabled
-// Enable/disable a policy
-const PostPoliciesByIdEnabledParamEnabled = z.boolean();
-/*
+  function zodSchemaPolicy() {
+      return z.object({
+          actions: z.string().optional().nullable(),
+          conditions: z.string(),
+          ctime: z.string().optional().nullable(),
+          description: z.string().optional().nullable(),
+          id: zodSchemaUUID().optional().nullable(),
+          isEnabled: z.boolean().optional().nullable(),
+          lastTriggered: z.number().int().optional().nullable(),
+          mtime: z.string().optional().nullable(),
+          name: z.string()
+      });
+  }
+
+  function zodSchemaMeta() {
+      return z.object({
+          count: z.number().int().optional().nullable()
+      });
+  }
+
+  function zodSchemaMapStringString() {
+      return z.record(z.string());
+  }
+
+  function zodSchemaHistoryItem() {
+      return z.object({
+          ctime: z.number().int().optional().nullable(),
+          hostName: z.string().optional().nullable(),
+          id: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaFact() {
+      return z.object({
+          id: z.number().int().optional().nullable(),
+          name: z.string().optional().nullable(),
+          type: zodSchemaFactType().optional().nullable()
+      });
+  }
+
+  function zodSchemaPagedResponseOfHistoryItem() {
+      return z.object({
+          links: zodSchemaMapStringString().optional().nullable(),
+          meta: zodSchemaMeta().optional().nullable(),
+          data: zodSchemaListHistoryItem().optional().nullable()
+      });
+  }
+
+  function zodSchemaFactType() {
+      return z.enum([ 'BOOLEAN', 'INT', 'LIST', 'STRING' ]);
+  }
+
+  function zodSchemaListUUID() {
+      return z.array(z.string());
+  }
+
+  function zodSchemaPagedResponseOfPolicy() {
+      return z.object({
+          links: zodSchemaMapStringString().optional().nullable(),
+          meta: zodSchemaMeta().optional().nullable(),
+          data: zodSchemaListPolicy().optional().nullable()
+      });
+  }
+
+  function zodSchemaList() {
+      return z.array(z.unknown());
+  }
+
+  function zodSchemaListPolicy() {
+      return z.array(zodSchemaPolicy());
+  }
+
+  function zodSchemaUUID() {
+      return z.string();
+  }
+
+  function zodSchemaListHistoryItem() {
+      return z.array(zodSchemaHistoryItem());
+  }
+
+  function zodSchema__Empty() {
+      return z.string().max(0).optional();
+  }
+}
+
+export namespace Operations {
+  // POST /policies/{id}/enabled
+  // Enable/disable a policy
+  export namespace PostPoliciesByIdEnabled {
+    const Enabled = z.boolean();
+    /*
  Params
-'id':UUID,
-'enabled'?:PostPoliciesByIdEnabledParamEnabled
+'id':Schemas.UUID,
+'enabled'?:Enabled
 */
-export const actionPostPoliciesByIdEnabled = (params) => {
-    const path = '/api/policies/v1.0/policies/{id}/enabled'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    if (params.enabled !== undefined) {
-        query.enabled = params.enabled.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/{id}/enabled'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        if (params.enabled !== undefined) {
+            query.enabled = params.enabled;
+        }
 
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /status
-export const actionGetStatus = () => {
-    const path = '/api/policies/v1.0/status';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(__Empty, '__Empty', 200) ]
-    })
-    .build();
-};
-
-// POST /policies/ids/enabled
-// Enable/disable policies identified by list of uuid in body
-const PostPoliciesIdsEnabledParamEnabled = z.boolean();
-/*
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /status
+  export namespace GetStatus {
+    export const actionCreator = () => {
+        const path = '/api/policies/v1.0/status';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.__Empty, '__Empty', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/ids/enabled
+  // Enable/disable policies identified by list of uuid in body
+  export namespace PostPoliciesIdsEnabled {
+    const Enabled = z.boolean();
+    /*
  Params
-'enabled'?:PostPoliciesIdsEnabledParamEnabled,
-body: ListUUID
+'enabled'?:Enabled,
+body: Schemas.ListUUID
 */
-export const actionPostPoliciesIdsEnabled = (params) => {
-    const path = '/api/policies/v1.0/policies/ids/enabled';
-    const query = {};
-    if (params.enabled !== undefined) {
-        query.enabled = params.enabled.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/ids/enabled';
+        const query = {};
+        if (params.enabled !== undefined) {
+            query.enabled = params.enabled;
+        }
 
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403)
-        ]
-    })
-    .build();
-};
-
-// GET /facts
-// Retrieve a list of fact (keys) along with their data types
-const GetFactsParamResponse200 = z.array(zodSchemaFact());
-export const actionGetFacts = () => {
-    const path = '/api/policies/v1.0/facts';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                GetFactsParamResponse200,
-                'GetFactsParamResponse200',
-                200
-            )
-        ]
-    })
-    .build();
-};
-
-// GET /policies
-// Return all policies for a given account
-const GetPoliciesParamFilterOpDescription = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-const GetPoliciesParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-const GetPoliciesParamFilterDescription = z.string();
-const GetPoliciesParamFilterIsEnabled = z.enum([ 'true', 'false' ]);
-const GetPoliciesParamFilterName = z.string();
-const GetPoliciesParamLimit = z.number().int();
-const GetPoliciesParamOffset = z.number().int();
-const GetPoliciesParamSortColumn = z.enum([
-    'name',
-    'description',
-    'is_enabled',
-    'mtime'
-]);
-const GetPoliciesParamSortDirection = z.enum([ 'asc', 'desc' ]);
-/*
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /facts
+  // Retrieve a list of fact (keys) along with their data types
+  export namespace GetFacts {
+    const Response200 = z.array(Schemas.Fact);
+    export const actionCreator = () => {
+        const path = '/api/policies/v1.0/facts';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Response200, 'Response200', 200) ]
+        })
+        .build();
+    };
+  }
+  // GET /policies
+  // Return all policies for a given account
+  export namespace GetPolicies {
+    const FilterOpDescription = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    const FilterOpName = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    const FilterDescription = z.string();
+    const FilterIsEnabled = z.enum([ 'true', 'false' ]);
+    const FilterName = z.string();
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const SortColumn = z.enum([ 'name', 'description', 'is_enabled', 'mtime' ]);
+    const SortDirection = z.enum([ 'asc', 'desc' ]);
+    /*
  Params
-'filterOpDescription'?:GetPoliciesParamFilterOpDescription,
-'filterOpName'?:GetPoliciesParamFilterOpName,
-'filterDescription'?:GetPoliciesParamFilterDescription,
-'filterIsEnabled'?:GetPoliciesParamFilterIsEnabled,
-'filterName'?:GetPoliciesParamFilterName,
-'limit'?:GetPoliciesParamLimit,
-'offset'?:GetPoliciesParamOffset,
-'sortColumn'?:GetPoliciesParamSortColumn,
-'sortDirection'?:GetPoliciesParamSortDirection
+'filterOpDescription'?:FilterOpDescription,
+'filterOpName'?:FilterOpName,
+'filterDescription'?:FilterDescription,
+'filterIsEnabled'?:FilterIsEnabled,
+'filterName'?:FilterName,
+'limit'?:Limit,
+'offset'?:Offset,
+'sortColumn'?:SortColumn,
+'sortDirection'?:SortDirection
 */
-export const actionGetPolicies = (params) => {
-    const path = '/api/policies/v1.0/policies';
-    const query = {};
-    if (params.filterOpDescription !== undefined) {
-        query['filter:op[description]'] = params.filterOpDescription.toString();
-    }
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies';
+        const query = {};
+        if (params.filterOpDescription !== undefined) {
+            query['filter:op[description]'] = params.filterOpDescription;
+        }
 
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
 
-    if (params.filterDescription !== undefined) {
-        query['filter[description]'] = params.filterDescription.toString();
-    }
+        if (params.filterDescription !== undefined) {
+            query['filter[description]'] = params.filterDescription;
+        }
 
-    if (params.filterIsEnabled !== undefined) {
-        query['filter[is_enabled]'] = params.filterIsEnabled.toString();
-    }
+        if (params.filterIsEnabled !== undefined) {
+            query['filter[is_enabled]'] = params.filterIsEnabled;
+        }
 
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
 
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
 
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
 
-    if (params.sortColumn !== undefined) {
-        query.sortColumn = params.sortColumn.toString();
-    }
+        if (params.sortColumn !== undefined) {
+            query.sortColumn = params.sortColumn;
+        }
 
-    if (params.sortDirection !== undefined) {
-        query.sortDirection = params.sortDirection.toString();
-    }
+        if (params.sortDirection !== undefined) {
+            query.sortDirection = params.sortDirection;
+        }
 
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(PagedResponseOfPolicy, 'PagedResponseOfPolicy', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// POST /policies
-// Validate (and possibly persist) a passed policy for the given account
-const PostPoliciesParamAlsoStore = z.boolean();
-const PostPoliciesParamResponse400 = z.object({
-    msg: z.string().optional().nullable()
-});
-const PostPoliciesParamResponse409 = z.object({
-    msg: z.string().optional().nullable()
-});
-/*
- Params
-'alsoStore'?:PostPoliciesParamAlsoStore,
-body: Policy
-*/
-export const actionPostPolicies = (params) => {
-    const path = '/api/policies/v1.0/policies';
-    const query = {};
-    if (params.alsoStore !== undefined) {
-        query.alsoStore = params.alsoStore.toString();
-    }
-
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(Policy, 'Policy', 201),
-            new ValidateRule(
-                PostPoliciesParamResponse400,
-                'PostPoliciesParamResponse400',
-                400
-            ),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(
-                PostPoliciesParamResponse409,
-                'PostPoliciesParamResponse409',
-                409
-            ),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /policies/{id}
-// Retrieve a single policy for a customer by its id
-/*
- Params
-'id':UUID
-*/
-export const actionGetPoliciesById = (params) => {
-    const path = '/api/policies/v1.0/policies/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(Policy, 'Policy', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// DELETE /policies/{id}
-// Delete a single policy for a customer by its id
-/*
- Params
-'id':UUID
-*/
-export const actionDeletePoliciesById = (params) => {
-    const path = '/api/policies/v1.0/policies/{id}'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// PUT /policies/{policyId}
-// Update a single policy for a customer by its id
-const PutPoliciesByPolicyIdParamDry = z.boolean();
-const PutPoliciesByPolicyIdParamResponse409 = z.object({
-    msg: z.string().optional().nullable()
-});
-/*
- Params
-'policyId':UUID,
-'dry'?:PutPoliciesByPolicyIdParamDry,
-body: Policy
-*/
-export const actionPutPoliciesByPolicyId = (params) => {
-    const path = '/api/policies/v1.0/policies/{policyId}'.replace(
-        '{policyId}',
-        params.policyId.toString()
-    );
-    const query = {};
-    if (params.dry !== undefined) {
-        query.dry = params.dry.toString();
-    }
-
-    return actionBuilder('PUT', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(
-                PutPoliciesByPolicyIdParamResponse409,
-                'PutPoliciesByPolicyIdParamResponse409',
-                409
-            )
-        ]
-    })
-    .build();
-};
-
-// POST /policies/validate-name
-// Validates the Policy.name and verifies if it is unique.
-const PostPoliciesValidateNameParamBody = z.string();
-/*
- Params
-'id'?:UUID,
-body: PostPoliciesValidateNameParamBody
-*/
-export const actionPostPoliciesValidateName = (params) => {
-    const path = '/api/policies/v1.0/policies/validate-name';
-    const query = {};
-    if (params.id !== undefined) {
-        query.id = params.id.toString();
-    }
-
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 409),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /policies/ids
-// Return all policy ids for a given account after applying the filters
-const GetPoliciesIdsParamFilterOpDescription = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-const GetPoliciesIdsParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'ilike',
-    'not_equal'
-]);
-const GetPoliciesIdsParamFilterDescription = z.string();
-const GetPoliciesIdsParamFilterIsEnabled = z.enum([ 'true', 'false' ]);
-const GetPoliciesIdsParamFilterName = z.string();
-/*
- Params
-'filterOpDescription'?:GetPoliciesIdsParamFilterOpDescription,
-'filterOpName'?:GetPoliciesIdsParamFilterOpName,
-'filterDescription'?:GetPoliciesIdsParamFilterDescription,
-'filterIsEnabled'?:GetPoliciesIdsParamFilterIsEnabled,
-'filterName'?:GetPoliciesIdsParamFilterName
-*/
-export const actionGetPoliciesIds = (params) => {
-    const path = '/api/policies/v1.0/policies/ids';
-    const query = {};
-    if (params.filterOpDescription !== undefined) {
-        query['filter:op[description]'] = params.filterOpDescription.toString();
-    }
-
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
-
-    if (params.filterDescription !== undefined) {
-        query['filter[description]'] = params.filterDescription.toString();
-    }
-
-    if (params.filterIsEnabled !== undefined) {
-        query['filter[is_enabled]'] = params.filterIsEnabled.toString();
-    }
-
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(List, 'List', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404)
-        ]
-    })
-    .build();
-};
-
-// DELETE /policies/ids
-// Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
-const DeletePoliciesIdsParamResponse200 = z.array(zodSchemaUUID());
-/*
- Params
-body: ListUUID
-*/
-export const actionDeletePoliciesIds = (params) => {
-    const path = '/api/policies/v1.0/policies/ids';
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(
-                DeletePoliciesIdsParamResponse200,
-                'DeletePoliciesIdsParamResponse200',
-                200
-            ),
-            new ValidateRule(__Empty, '__Empty', 403)
-        ]
-    })
-    .build();
-};
-
-// POST /policies/validate
-// Validates a Policy condition
-/*
- Params
-body: Policy
-*/
-export const actionPostPoliciesValidate = (params) => {
-    const path = '/api/policies/v1.0/policies/validate';
-    const query = {};
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(__Empty, '__Empty', 200),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-// GET /
-// Just a filler to have a defined return code for the base path
-export const actionGet = () => {
-    const path = '/api/policies/v1.0/';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(__Empty, '__Empty', 404) ]
-    })
-    .build();
-};
-
-// GET /policies/{id}/history/trigger
-// Retrieve the trigger history of a single policy
-const GetPoliciesByIdHistoryTriggerParamFilterOpId = z.enum([
-    'equal',
-    'not_equal',
-    'like'
-]);
-const GetPoliciesByIdHistoryTriggerParamFilterOpName = z.enum([
-    'equal',
-    'like',
-    'not_equal'
-]);
-const GetPoliciesByIdHistoryTriggerParamFilterId = z.string();
-const GetPoliciesByIdHistoryTriggerParamFilterName = z.string();
-const GetPoliciesByIdHistoryTriggerParamLimit = z.number().int();
-const GetPoliciesByIdHistoryTriggerParamOffset = z.number().int();
-const GetPoliciesByIdHistoryTriggerParamSortColumn = z.enum([
-    'hostName',
-    'id',
-    'ctime'
-]);
-const GetPoliciesByIdHistoryTriggerParamSortDirection = z.enum([ 'asc', 'desc' ]);
-/*
- Params
-'id':UUID,
-'filterOpId'?:GetPoliciesByIdHistoryTriggerParamFilterOpId,
-'filterOpName'?:GetPoliciesByIdHistoryTriggerParamFilterOpName,
-'filterId'?:GetPoliciesByIdHistoryTriggerParamFilterId,
-'filterName'?:GetPoliciesByIdHistoryTriggerParamFilterName,
-'limit'?:GetPoliciesByIdHistoryTriggerParamLimit,
-'offset'?:GetPoliciesByIdHistoryTriggerParamOffset,
-'sortColumn'?:GetPoliciesByIdHistoryTriggerParamSortColumn,
-'sortDirection'?:GetPoliciesByIdHistoryTriggerParamSortDirection
-*/
-export const actionGetPoliciesByIdHistoryTrigger = (params) => {
-    const path = '/api/policies/v1.0/policies/{id}/history/trigger'.replace(
-        '{id}',
-        params.id.toString()
-    );
-    const query = {};
-    if (params.filterOpId !== undefined) {
-        query['filter:op[id]'] = params.filterOpId.toString();
-    }
-
-    if (params.filterOpName !== undefined) {
-        query['filter:op[name]'] = params.filterOpName.toString();
-    }
-
-    if (params.filterId !== undefined) {
-        query['filter[id]'] = params.filterId.toString();
-    }
-
-    if (params.filterName !== undefined) {
-        query['filter[name]'] = params.filterName.toString();
-    }
-
-    if (params.limit !== undefined) {
-        query.limit = params.limit.toString();
-    }
-
-    if (params.offset !== undefined) {
-        query.offset = params.offset.toString();
-    }
-
-    if (params.sortColumn !== undefined) {
-        query.sortColumn = params.sortColumn.toString();
-    }
-
-    if (params.sortDirection !== undefined) {
-        query.sortDirection = params.sortDirection.toString();
-    }
-
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [
-            new ValidateRule(
-                PagedResponseOfHistoryItem,
-                'PagedResponseOfHistoryItem',
-                200
-            ),
-            new ValidateRule(__Empty, '__Empty', 400),
-            new ValidateRule(__Empty, '__Empty', 403),
-            new ValidateRule(__Empty, '__Empty', 404),
-            new ValidateRule(__Empty, '__Empty', 500)
-        ]
-    })
-    .build();
-};
-
-export function zodSchemaPolicy() {
-    return z.object({
-        actions: z.string().optional().nullable(),
-        conditions: z.string(),
-        ctime: z.string().optional().nullable(),
-        description: z.string().optional().nullable(),
-        id: zodSchemaUUID().optional().nullable(),
-        isEnabled: z.boolean().optional().nullable(),
-        lastTriggered: z.number().int().optional().nullable(),
-        mtime: z.string().optional().nullable(),
-        name: z.string()
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(
+                    Schemas.PagedResponseOfPolicy,
+                    'PagedResponseOfPolicy',
+                    200
+                ),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies
+  // Validate (and possibly persist) a passed policy for the given account
+  export namespace PostPolicies {
+    const AlsoStore = z.boolean();
+    const Response400 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
-
-export function zodSchemaMeta() {
-    return z.object({
-        count: z.number().int().optional().nullable()
+    const Response409 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
+    /*
+ Params
+'alsoStore'?:AlsoStore,
+body: Schemas.Policy
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies';
+        const query = {};
+        if (params.alsoStore !== undefined) {
+            query.alsoStore = params.alsoStore;
+        }
 
-export function zodSchemaMapStringString() {
-    return z.record(z.string());
-}
-
-export function zodSchemaHistoryItem() {
-    return z.object({
-        ctime: z.number().int().optional().nullable(),
-        hostName: z.string().optional().nullable(),
-        id: z.string().optional().nullable()
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.Policy, 'Policy', 201),
+                new ValidateRule(Response400, 'Response400', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Response409, 'Response409', 409),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/{id}
+  // Retrieve a single policy for a customer by its id
+  export namespace GetPoliciesById {
+    /*
+ Params
+'id':Schemas.UUID
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.Policy, 'Policy', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // DELETE /policies/{id}
+  // Delete a single policy for a customer by its id
+  export namespace DeletePoliciesById {
+    /*
+ Params
+'id':Schemas.UUID
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/{id}'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // PUT /policies/{policyId}
+  // Update a single policy for a customer by its id
+  export namespace PutPoliciesByPolicyId {
+    const Dry = z.boolean();
+    const Response409 = z.object({
+        msg: z.string().optional().nullable()
     });
-}
+    /*
+ Params
+'policyId':Schemas.UUID,
+'dry'?:Dry,
+body: Schemas.Policy
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/{policyId}'.replace(
+            '{policyId}',
+            params.policyId.toString()
+        );
+        const query = {};
+        if (params.dry !== undefined) {
+            query.dry = params.dry;
+        }
 
-export function zodSchemaFact() {
-    return z.object({
-        id: z.number().int().optional().nullable(),
-        name: z.string().optional().nullable(),
-        type: zodSchemaFactType().optional().nullable()
-    });
-}
+        return actionBuilder('PUT', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Response409, 'Response409', 409)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/validate-name
+  // Validates the Policy.name and verifies if it is unique.
+  export namespace PostPoliciesValidateName {
+    const Body = z.string();
+    /*
+ Params
+'id'?:Schemas.UUID,
+body: Body
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/validate-name';
+        const query = {};
+        if (params.id !== undefined) {
+            query.id = params.id;
+        }
 
-export function zodSchemaPagedResponseOfHistoryItem() {
-    return z.object({
-        links: zodSchemaMapStringString().optional().nullable(),
-        meta: zodSchemaMeta().optional().nullable(),
-        data: zodSchemaListHistoryItem().optional().nullable()
-    });
-}
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 409),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/ids
+  // Return all policy ids for a given account after applying the filters
+  export namespace GetPoliciesIds {
+    const FilterOpDescription = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    const FilterOpName = z.enum([ 'equal', 'like', 'ilike', 'not_equal' ]);
+    const FilterDescription = z.string();
+    const FilterIsEnabled = z.enum([ 'true', 'false' ]);
+    const FilterName = z.string();
+    /*
+ Params
+'filterOpDescription'?:FilterOpDescription,
+'filterOpName'?:FilterOpName,
+'filterDescription'?:FilterDescription,
+'filterIsEnabled'?:FilterIsEnabled,
+'filterName'?:FilterName
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/ids';
+        const query = {};
+        if (params.filterOpDescription !== undefined) {
+            query['filter:op[description]'] = params.filterOpDescription;
+        }
 
-export function zodSchemaFactType() {
-    return z.enum([ 'BOOLEAN', 'INT', 'LIST', 'STRING' ]);
-}
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
 
-export function zodSchemaListUUID() {
-    return z.array(z.string());
-}
+        if (params.filterDescription !== undefined) {
+            query['filter[description]'] = params.filterDescription;
+        }
 
-export function zodSchemaPagedResponseOfPolicy() {
-    return z.object({
-        links: zodSchemaMapStringString().optional().nullable(),
-        meta: zodSchemaMeta().optional().nullable(),
-        data: zodSchemaListPolicy().optional().nullable()
-    });
-}
+        if (params.filterIsEnabled !== undefined) {
+            query['filter[is_enabled]'] = params.filterIsEnabled;
+        }
 
-export function zodSchemaList() {
-    return z.array(z.unknown());
-}
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
 
-export function zodSchemaListPolicy() {
-    return z.array(zodSchemaPolicy());
-}
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.List, 'List', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404)
+            ]
+        })
+        .build();
+    };
+  }
+  // DELETE /policies/ids
+  // Delete policies for a customer by the ids passed in the body. Result will be a list of deleted UUIDs
+  export namespace DeletePoliciesIds {
+    const Response200 = z.array(Schemas.UUID);
+    /*
+ Params
+body: Schemas.ListUUID
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/ids';
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Response200, 'Response200', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403)
+            ]
+        })
+        .build();
+    };
+  }
+  // POST /policies/validate
+  // Validates a Policy condition
+  export namespace PostPoliciesValidate {
+    /*
+ Params
+body: Schemas.Policy
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/validate';
+        const query = {};
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.__Empty, '__Empty', 200),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
+  // GET /
+  // Just a filler to have a defined return code for the base path
+  export namespace Get {
+    export const actionCreator = () => {
+        const path = '/api/policies/v1.0/';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.__Empty, '__Empty', 404) ]
+        })
+        .build();
+    };
+  }
+  // GET /policies/{id}/history/trigger
+  // Retrieve the trigger history of a single policy
+  export namespace GetPoliciesByIdHistoryTrigger {
+    const FilterOpId = z.enum([ 'equal', 'not_equal', 'like' ]);
+    const FilterOpName = z.enum([ 'equal', 'like', 'not_equal' ]);
+    const FilterId = z.string();
+    const FilterName = z.string();
+    const Limit = z.number().int();
+    const Offset = z.number().int();
+    const SortColumn = z.enum([ 'hostName', 'id', 'ctime' ]);
+    const SortDirection = z.enum([ 'asc', 'desc' ]);
+    /*
+ Params
+'id':Schemas.UUID,
+'filterOpId'?:FilterOpId,
+'filterOpName'?:FilterOpName,
+'filterId'?:FilterId,
+'filterName'?:FilterName,
+'limit'?:Limit,
+'offset'?:Offset,
+'sortColumn'?:SortColumn,
+'sortDirection'?:SortDirection
+*/
+    export const actionCreator = (params) => {
+        const path = '/api/policies/v1.0/policies/{id}/history/trigger'.replace(
+            '{id}',
+            params.id.toString()
+        );
+        const query = {};
+        if (params.filterOpId !== undefined) {
+            query['filter:op[id]'] = params.filterOpId;
+        }
 
-export function zodSchemaUUID() {
-    return z.string();
-}
+        if (params.filterOpName !== undefined) {
+            query['filter:op[name]'] = params.filterOpName;
+        }
 
-export function zodSchemaListHistoryItem() {
-    return z.array(zodSchemaHistoryItem());
-}
+        if (params.filterId !== undefined) {
+            query['filter[id]'] = params.filterId;
+        }
 
-export function zodSchema__Empty() {
-    return z.string().max(0).optional();
+        if (params.filterName !== undefined) {
+            query['filter[name]'] = params.filterName;
+        }
+
+        if (params.limit !== undefined) {
+            query.limit = params.limit;
+        }
+
+        if (params.offset !== undefined) {
+            query.offset = params.offset;
+        }
+
+        if (params.sortColumn !== undefined) {
+            query.sortColumn = params.sortColumn;
+        }
+
+        if (params.sortDirection !== undefined) {
+            query.sortDirection = params.sortDirection;
+        }
+
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [
+                new ValidateRule(
+                    Schemas.PagedResponseOfHistoryItem,
+                    'PagedResponseOfHistoryItem',
+                    200
+                ),
+                new ValidateRule(Schemas.__Empty, '__Empty', 400),
+                new ValidateRule(Schemas.__Empty, '__Empty', 403),
+                new ValidateRule(Schemas.__Empty, '__Empty', 404),
+                new ValidateRule(Schemas.__Empty, '__Empty', 500)
+            ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -4481,100 +3981,100 @@ import {
     ActionValidatableConfig
 } from 'openapi2typescript/react-fetching-library';
 
-export const Fruit = zodSchemaFruit();
-export type Fruit = z.infer<typeof Fruit>;
+export namespace Schemas {
+  export const Fruit = zodSchemaFruit();
+  export type Fruit = z.infer<typeof Fruit>;
 
-export const Message = zodSchemaMessage();
-export type Message = z.infer<typeof Message>;
+  export const Message = zodSchemaMessage();
+  export type Message = z.infer<typeof Message>;
 
-export const SetFruit = zodSchemaSetFruit();
-export type SetFruit = z.infer<typeof SetFruit>;
+  export const SetFruit = zodSchemaSetFruit();
+  export type SetFruit = z.infer<typeof SetFruit>;
 
-// GET /fruits
-export type GetFruitsPayload =
-  | ValidatedResponse<'SetFruit', 200, SetFruit>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionGetFruits = Action<GetFruitsPayload, ActionValidatableConfig>;
-export const actionGetFruits = (): ActionGetFruits => {
-    const path = '/fruits';
-    const query = {} as Record<string, any>;
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(SetFruit, 'SetFruit', 200) ]
-    })
-    .build();
-};
+  function zodSchemaFruit() {
+      return z.object({
+          description: z.string().optional().nullable(),
+          name: z.string().optional().nullable()
+      });
+  }
 
-// POST /fruits
-export interface PostFruits {
-  body: Fruit;
+  function zodSchemaMessage() {
+      return z.object({
+          description: z.string().optional().nullable()
+      });
+  }
+
+  function zodSchemaSetFruit() {
+      return z.array(zodSchemaFruit());
+  }
 }
 
-export type PostFruitsPayload =
-  | ValidatedResponse<'SetFruit', 200, SetFruit>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionPostFruits = Action<
-  PostFruitsPayload,
-  ActionValidatableConfig
->;
-export const actionPostFruits = (params: PostFruits): ActionPostFruits => {
-    const path = '/fruits';
-    const query = {} as Record<string, any>;
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(SetFruit, 'SetFruit', 200) ]
-    })
-    .build();
-};
+export namespace Operations {
+  // GET /fruits
+  export namespace GetFruits {
+    export type Payload =
+      | ValidatedResponse<'SetFruit', 200, Schemas.SetFruit>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (): ActionCreator => {
+        const path = '/fruits';
+        const query = {} as Record<string, any>;
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.SetFruit, 'SetFruit', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /fruits
+  export namespace PostFruits {
+    export interface Params {
+      body: Schemas.Fruit;
+    }
 
-// DELETE /fruits
-export interface DeleteFruits {
-  body: Fruit;
-}
+    export type Payload =
+      | ValidatedResponse<'SetFruit', 200, Schemas.SetFruit>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/fruits';
+        const query = {} as Record<string, any>;
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.SetFruit, 'SetFruit', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /fruits
+  export namespace DeleteFruits {
+    export interface Params {
+      body: Schemas.Fruit;
+    }
 
-export type DeleteFruitsPayload =
-  | ValidatedResponse<'SetFruit', 200, SetFruit>
-  | ValidatedResponse<'Message', 400, Message>
-  | ValidatedResponse<'unknown', undefined, unknown>;
-export type ActionDeleteFruits = Action<
-  DeleteFruitsPayload,
-  ActionValidatableConfig
->;
-export const actionDeleteFruits = (
-    params: DeleteFruits
-): ActionDeleteFruits => {
-    const path = '/fruits';
-    const query = {} as Record<string, any>;
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(SetFruit, 'SetFruit', 200),
-            new ValidateRule(Message, 'Message', 400)
-        ]
-    })
-    .build();
-};
-
-export function zodSchemaFruit() {
-    return z.object({
-        description: z.string().optional().nullable(),
-        name: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaMessage() {
-    return z.object({
-        description: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaSetFruit() {
-    return z.array(zodSchemaFruit());
+    export type Payload =
+      | ValidatedResponse<'SetFruit', 200, Schemas.SetFruit>
+      | ValidatedResponse<'Message', 400, Schemas.Message>
+      | ValidatedResponse<'unknown', undefined, unknown>;
+    export type ActionCreator = Action<Payload, ActionValidatableConfig>;
+    export const actionCreator = (params: Params): ActionCreator => {
+        const path = '/fruits';
+        const query = {} as Record<string, any>;
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.SetFruit, 'SetFruit', 200),
+                new ValidateRule(Schemas.Message, 'Message', 400)
+            ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;
@@ -4588,76 +4088,84 @@ import * as z from 'zod';
 import { ValidateRule } from 'openapi2typescript';
 import { actionBuilder } from 'openapi2typescript/react-fetching-library';
 
-export const Fruit = zodSchemaFruit();
+export namespace Schemas {
+  export const Fruit = zodSchemaFruit();
 
-export const Message = zodSchemaMessage();
+  export const Message = zodSchemaMessage();
 
-export const SetFruit = zodSchemaSetFruit();
+  export const SetFruit = zodSchemaSetFruit();
 
-// GET /fruits
-export const actionGetFruits = () => {
-    const path = '/fruits';
-    const query = {};
-    return actionBuilder('GET', path)
-    .queryParams(query)
-    .config({
-        rules: [ new ValidateRule(SetFruit, 'SetFruit', 200) ]
-    })
-    .build();
-};
+  function zodSchemaFruit() {
+      return z.object({
+          description: z.string().optional().nullable(),
+          name: z.string().optional().nullable()
+      });
+  }
 
-// POST /fruits
-/*
- Params
-body: Fruit
-*/
-export const actionPostFruits = (params) => {
-    const path = '/fruits';
-    const query = {};
-    return actionBuilder('POST', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [ new ValidateRule(SetFruit, 'SetFruit', 200) ]
-    })
-    .build();
-};
+  function zodSchemaMessage() {
+      return z.object({
+          description: z.string().optional().nullable()
+      });
+  }
 
-// DELETE /fruits
-/*
- Params
-body: Fruit
-*/
-export const actionDeleteFruits = (params) => {
-    const path = '/fruits';
-    const query = {};
-    return actionBuilder('DELETE', path)
-    .queryParams(query)
-    .data(params.body)
-    .config({
-        rules: [
-            new ValidateRule(SetFruit, 'SetFruit', 200),
-            new ValidateRule(Message, 'Message', 400)
-        ]
-    })
-    .build();
-};
-
-export function zodSchemaFruit() {
-    return z.object({
-        description: z.string().optional().nullable(),
-        name: z.string().optional().nullable()
-    });
+  function zodSchemaSetFruit() {
+      return z.array(zodSchemaFruit());
+  }
 }
 
-export function zodSchemaMessage() {
-    return z.object({
-        description: z.string().optional().nullable()
-    });
-}
-
-export function zodSchemaSetFruit() {
-    return z.array(zodSchemaFruit());
+export namespace Operations {
+  // GET /fruits
+  export namespace GetFruits {
+    export const actionCreator = () => {
+        const path = '/fruits';
+        const query = {};
+        return actionBuilder('GET', path)
+        .queryParams(query)
+        .config({
+            rules: [ new ValidateRule(Schemas.SetFruit, 'SetFruit', 200) ]
+        })
+        .build();
+    };
+  }
+  // POST /fruits
+  export namespace PostFruits {
+    /*
+ Params
+body: Schemas.Fruit
+*/
+    export const actionCreator = (params) => {
+        const path = '/fruits';
+        const query = {};
+        return actionBuilder('POST', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [ new ValidateRule(Schemas.SetFruit, 'SetFruit', 200) ]
+        })
+        .build();
+    };
+  }
+  // DELETE /fruits
+  export namespace DeleteFruits {
+    /*
+ Params
+body: Schemas.Fruit
+*/
+    export const actionCreator = (params) => {
+        const path = '/fruits';
+        const query = {};
+        return actionBuilder('DELETE', path)
+        .queryParams(query)
+        .data(params.body)
+        .config({
+            rules: [
+                new ValidateRule(Schemas.SetFruit, 'SetFruit', 200),
+                new ValidateRule(Schemas.Message, 'Message', 400)
+            ]
+        })
+        .build();
+    };
+  }
 }
 "
 `;

--- a/packages/openapi2typescript/package.json
+++ b/packages/openapi2typescript/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "build": "rollup --config",
+    "start": "rollup --config --watch --cache",
     "lint": "eslint --ext js,ts,tsx src",
     "lint:fix": "eslint --ext js,ts,tsx src --fix",
     "test": "jest --verbose",

--- a/packages/openapi2typescript/rollup.config.js
+++ b/packages/openapi2typescript/rollup.config.js
@@ -3,106 +3,72 @@ import json from '@rollup/plugin-json';
 import typescript from '@rollup/plugin-typescript';
 import compiler from '@ampproject/rollup-plugin-closure-compiler';
 import dts from 'rollup-plugin-dts';
+import execute from 'rollup-plugin-execute';
 
 const extensions = [ '.js', '.ts' ];
 
-const config = [
-    {
-        input: 'src/index.ts',
-        output: [
-            {
-                file: 'index.js',
-                format: 'umd',
-                name: 'index',
-                sourcemap: true
-            },
-            {
-                file: 'esm/index.js',
-                format: 'esm',
-                sourcemap: true
-            },
-            {
-                file: 'cjs/index.js',
-                format: 'cjs',
-                sourcemap: true
-            }
-        ],
-        external: [
-            'zod'
-        ],
-        plugins: [
-            json(),
-            typescript({
-                allowSyntheticDefaultImports: true
-            }),
-            commonjs({
-                extensions
-            }),
-            compiler()
-        ]
-    },
-    {
-        input: 'src/index.ts',
-        output: [
-            {
-                file: 'index.d.ts'
-            }
-        ],
-        external: [
-            'zod'
-        ],
-        plugins: [
-            dts()
-        ]
-    },
-    {
-        input: 'src/react-fetching-library.ts',
-        output: [
-            {
-                file: 'react-fetching-library.js',
-                format: 'umd',
-                name: 'react-fetching-library',
-                sourcemap: true
-            },
-            {
-                file: 'esm/react-fetching-library.js',
-                format: 'esm',
-                sourcemap: true
-            },
-            {
-                file: 'cjs/react-fetching-library.js',
-                format: 'cjs',
-                sourcemap: true
-            }
-        ],
-        external: [
-            'zod', 'react-fetching-library'
-        ],
-        plugins: [
-            json(),
-            typescript({
-                allowSyntheticDefaultImports: true
-            }),
-            commonjs({
-                extensions
-            }),
-            compiler()
-        ]
-    },
-    {
-        input: 'src/react-fetching-library.ts',
-        output: [
-            {
-                file: 'react-fetching-library.d.ts'
-            }
-        ],
-        external: [
-            'zod', 'react-fetching-library'
-        ],
-        plugins: [
-            dts()
-        ]
-    }
-];
+const buildItemConfig = (inputFilename, isWatch, external) => {
+    const outputs = [
+        {
+            file: `${inputFilename}.js`,
+            format: 'umd',
+            name: 'index',
+            sourcemap: true
+        }
+    ];
 
-export default config;
+    const dtsPlugin = [ dts() ];
+
+    if (!isWatch) {
+        outputs.push(
+            {
+                file: `esm/${inputFilename}.js`,
+                format: 'esm',
+                sourcemap: true
+            },
+            {
+                file: `cjs/${inputFilename}.js`,
+                format: 'cjs',
+                sourcemap: true
+            }
+        );
+    } else {
+        dtsPlugin.push(execute('which yalc > /dev/null && yalc publish --changed --push'));
+    }
+
+    return [
+        {
+            input: `src/${inputFilename}.ts`,
+            output: outputs,
+            external,
+            plugins: [
+                json(),
+                typescript({
+                    allowSyntheticDefaultImports: true
+                }),
+                commonjs({
+                    extensions
+                }),
+                compiler()
+            ]
+        },
+        {
+            input: `src/${inputFilename}.ts`,
+            output: [
+                {
+                    file: `${inputFilename}.d.ts`
+                }
+            ],
+            external,
+            plugins: dtsPlugin
+        }
+    ];
+};
+
+export default function makeConfig(params) {
+
+    return [
+        ...buildItemConfig('index', !!params.watch, [ 'zod' ]),
+        ...buildItemConfig('react-fetching-library', !!params.watch, [ 'zod', 'react-fetching-library' ])
+    ];
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,7 +1828,7 @@
     sanitize-html "^1.25.0"
 
 "@redhat-cloud-services/insights-common-typescript@file:packages/insights-common-typescript":
-  version "3.0.6"
+  version "3.0.7"
   dependencies:
     camelcase "5.3.1"
     classnames "2.2.6"
@@ -7684,7 +7684,7 @@ inquirer@6.5.2, inquirer@^6.2.0, inquirer@^6.2.2:
     through "^2.3.6"
 
 "insights-common-typescript@file:packages/insights-common-typescript":
-  version "3.0.6"
+  version "3.0.7"
   dependencies:
     camelcase "5.3.1"
     classnames "2.2.6"
@@ -12157,6 +12157,11 @@ rollup-plugin-dts@1.4.12:
   integrity sha512-1TIHkYbxXkwsqW/l//CuBu7Kc4oriCe7XEzFr5wHMAeRtgxSMjaNWiyB/4n7Tgv6NHe/Z1R4GJiualXTO4cc/A==
   optionalDependencies:
     "@babel/code-frame" "^7.10.4"
+
+rollup-plugin-execute@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-execute/-/rollup-plugin-execute-1.1.1.tgz#ee7bcb293e48bc599232b66b66473763e3cb8965"
+  integrity sha512-isCNR/VrwlEfWJMwsnmt5TBRod8dW1IjVRxcXCBrxDmVTeA1IXjzeLSS3inFBmRD7KDPlo38KSb2mh5v5BoWgA==
 
 rollup@2.26.10:
   version "2.26.10"


### PR DESCRIPTION
All: Added `start` command to run a build in watch mode for all the components. If `yalc` is installed, it will autodeploy on changes.

# insights-common-typescript
- Allows filters (useFilter, PrimaryFIlter and Page filters) to have multiple elements
- Added `useUrlStateMultipleOptions`

# openapi2typescript-cli
- Grouped all components into namespaces for easier navigation

# openapi2typescript
- Support for having query params as arrays