### PR TITLE
Improvements

### DIFF
--- a/packages/insights-common-typescript/src/components/Modals/ActionModal.tsx
+++ b/packages/insights-common-typescript/src/components/Modals/ActionModal.tsx
@@ -26,7 +26,9 @@ export interface ActionModalProps extends Pick<ModalProps, 'variant' | 'titleIco
     actionButtonTitle: string;
     actionButtonVariant: ButtonVariant;
     actionButtonDisabled?: boolean;
+    actionButtonHidden?: boolean;
     cancelButtonTitle?: string;
+    cancelButtonVariant?: ButtonVariant;
 }
 
 export const ActionModal: React.FunctionComponent<ActionModalProps> = (props) => {
@@ -46,6 +48,43 @@ export const ActionModal: React.FunctionComponent<ActionModalProps> = (props) =>
         }
     }, [ props.onAction, props.onClose ]);
 
+    const actions = React.useMemo(() => {
+        const actionContent: Array<React.ReactNode> = [];
+        if (!props.actionButtonHidden) {
+            actionContent.push(<Button
+                ouiaId="action"
+                key="action"
+                variant={ props.actionButtonVariant }
+                isDisabled={ props.isPerformingAction || props.actionButtonDisabled }
+                onClick={ actionCallback }
+            >
+                { props.isPerformingAction ? <Spinner size="md"/> : props.actionButtonTitle }
+            </Button>);
+        }
+
+        actionContent.push(<Button
+            ouiaId="cancel"
+            key="cancel"
+            variant={ props.cancelButtonVariant ?? ButtonVariant.link }
+            isDisabled={ props.isPerformingAction }
+            onClick={ close }
+        >
+            { props.cancelButtonTitle ?? 'Cancel' }
+        </Button>);
+
+        return actionContent;
+    }, [
+        props.actionButtonVariant,
+        props.actionButtonTitle,
+        props.actionButtonDisabled,
+        props.actionButtonHidden,
+        props.isPerformingAction,
+        props.cancelButtonTitle,
+        props.cancelButtonVariant,
+        close,
+        actionCallback
+    ]);
+
     return (
         <Modal
             title={ props.title }
@@ -53,26 +92,7 @@ export const ActionModal: React.FunctionComponent<ActionModalProps> = (props) =>
             onClose={ close }
             variant={ props.variant ?? ModalVariant.small }
             titleIconVariant={ props.titleIconVariant }
-            actions={ [
-                <Button
-                    ouiaId="action"
-                    key="action"
-                    variant={ props.actionButtonVariant }
-                    isDisabled={ props.isPerformingAction || props.actionButtonDisabled }
-                    onClick={ actionCallback }
-                >
-                    { props.isPerformingAction ? <Spinner size="md"/> : props.actionButtonTitle }
-                </Button>,
-                <Button
-                    ouiaId="cancel"
-                    key="cancel"
-                    variant={ ButtonVariant.link }
-                    isDisabled={ props.isPerformingAction }
-                    onClick={ close }
-                >
-                    { props.cancelButtonTitle ?? 'Cancel' }
-                </Button>
-            ] }
+            actions={ actions }
         >
             { props.error && (
                 <>

--- a/packages/insights-common-typescript/src/components/Modals/DeleteModal.tsx
+++ b/packages/insights-common-typescript/src/components/Modals/DeleteModal.tsx
@@ -1,26 +1,23 @@
 import * as React from 'react';
 import { ActionModal, ActionModalProps } from './ActionModal';
 import { ButtonVariant } from '@patternfly/react-core';
+import { SemiPartial } from '../../types/Utils';
 
-type InheritedProps = 'isOpen' | 'title' | 'content'  | 'onClose' | 'error' | 'variant' | 'titleIconVariant';
+type ChangedProps = 'isPerformingAction' | 'onAction';
+type InheritedProps = 'isOpen' | 'title' | 'content'  | 'onClose' | 'error' | 'variant';
 
-export interface DeleteModalProps extends Pick<ActionModalProps, InheritedProps> {
+export type DeleteModalProps = Omit<SemiPartial<ActionModalProps, InheritedProps>, ChangedProps> & {
     isDeleting: boolean;
     onDelete: () => boolean | Promise<boolean>;
 }
 
 export const DeleteModal: React.FunctionComponent<DeleteModalProps> = (props) => {
     return <ActionModal
-        isOpen={ props.isOpen }
-        isPerformingAction={ props.isDeleting }
-        title={ props.title }
-        content={ props.content }
-        onClose={ props.onClose }
-        onAction={ props.onDelete }
-        actionButtonTitle="Remove"
-        actionButtonVariant={ ButtonVariant.danger }
-        error={ props.error }
-        variant={ props.variant }
+        { ...props }
+        actionButtonTitle={ props.actionButtonTitle ?? 'Remove' }
+        actionButtonVariant={ props.actionButtonVariant ?? ButtonVariant.danger }
         titleIconVariant={ props.titleIconVariant ?? 'warning' }
+        isPerformingAction={ props.isDeleting }
+        onAction={ props.onDelete }
     />;
 };

--- a/packages/insights-common-typescript/src/components/Modals/SaveModal.tsx
+++ b/packages/insights-common-typescript/src/components/Modals/SaveModal.tsx
@@ -1,28 +1,22 @@
 import * as React from 'react';
 import { ActionModal, ActionModalProps } from './ActionModal';
 import { ButtonVariant } from '@patternfly/react-core';
+import { SemiPartial } from '../../types/Utils';
 
+type ChangedProps = 'isPerformingAction' | 'onAction';
 type InheritedProps = 'isOpen' | 'title' | 'content'  | 'onClose' | 'error' | 'actionButtonDisabled' | 'variant' | 'titleIconVariant';
 
-export interface SaveModalProps extends Pick<ActionModalProps, InheritedProps> {
+export type SaveModalProps = Omit<SemiPartial<ActionModalProps, InheritedProps>, ChangedProps> & {
     isSaving: boolean;
     onSave: () => boolean | Promise<boolean>;
-    actionButtonTitle?: string;
 }
 
 export const SaveModal: React.FunctionComponent<SaveModalProps> = (props) => {
     return <ActionModal
-        isOpen={ props.isOpen }
+        { ...props }
         isPerformingAction={ props.isSaving }
-        title={ props.title }
-        content={ props.content }
-        onClose={ props.onClose }
         onAction={ props.onSave }
         actionButtonTitle={ props.actionButtonTitle ?? 'Save' }
-        actionButtonVariant={ ButtonVariant.primary }
-        error={ props.error }
-        actionButtonDisabled={ props.actionButtonDisabled }
-        variant={ props.variant }
-        titleIconVariant={ props.titleIconVariant }
+        actionButtonVariant={ props.actionButtonVariant ?? ButtonVariant.primary }
     />;
 };

--- a/packages/insights-common-typescript/src/types/Environment.ts
+++ b/packages/insights-common-typescript/src/types/Environment.ts
@@ -13,18 +13,25 @@ const environments = [ ...nonBetaEnvironments, ...betaEnvironments ] as const;
 const prodEnvironments = [ 'prod', 'prod-beta' ] as const;
 const nonProdEnvironments = environments.filter(v => !v.startsWith('prod' as const));
 
+const ciEnvironments: ReadonlyArray<Environment> = [ 'ci', 'ci-beta' ];
+const qaEnvironments: ReadonlyArray<Environment> = [ 'qa', 'qa-beta' ];
+const stageEnvironments: ReadonlyArray<Environment> = [ 'stage', 'stage-beta' ];
+
 export type NonBetaEnvironment = typeof nonBetaEnvironments[number];
 export type BetaEnvironment = typeof betaEnvironments[number];
 
 export type Environment = NonBetaEnvironment | BetaEnvironment;
 
-type Environments = Record<'all' | 'beta' | 'nonBeta' | 'prod' | 'nonProd', ReadonlyArray<Environment>>;
+type Environments = Record<'all' | 'beta' | 'nonBeta' | 'prod' | 'nonProd' | 'ci' | 'qa' | 'stage', ReadonlyArray<Environment>>;
 export const Environments: Environments = {
     all: environments,
     beta: betaEnvironments,
     nonBeta: nonBetaEnvironments,
     prod: prodEnvironments,
-    nonProd: nonProdEnvironments
+    nonProd: nonProdEnvironments,
+    ci: ciEnvironments,
+    qa: qaEnvironments,
+    stage: stageEnvironments
 };
 
 export const getInsightsEnvironment = (insights: InsightsType): Environment => {

--- a/packages/insights-common-typescript/src/types/Utils.ts
+++ b/packages/insights-common-typescript/src/types/Utils.ts
@@ -1,0 +1,2 @@
+// Partial all but specified properties
+export type SemiPartial<T, K extends keyof T> = Pick<T, K> & Partial<Omit<T, K>>;

--- a/packages/insights-common-typescript/src/types/index.ts
+++ b/packages/insights-common-typescript/src/types/index.ts
@@ -4,3 +4,4 @@ export * from './Rbac';
 export * from './HasToString';
 export * from './Filters';
 export * from './Environment';
+export * from './Utils';

--- a/packages/openapi2typescript-cli/src/core/ApiDescriptorBuilder.ts
+++ b/packages/openapi2typescript-cli/src/core/ApiDescriptorBuilder.ts
@@ -413,7 +413,7 @@ class ApiDescriptorBuilder {
 
     private getBasePath(): string {
         if (this.openapi.servers) {
-            const variables = this.openapi.servers[0].variables;
+            const variables = this.openapi.servers[0]?.variables;
             if (variables?.basePath?.default) {
                 return variables.basePath.default;
             }

--- a/packages/openapi2typescript-cli/tests/core/ApiDescriptorBuilder.test.ts
+++ b/packages/openapi2typescript-cli/tests/core/ApiDescriptorBuilder.test.ts
@@ -38,6 +38,13 @@ describe('src/core/ApiDescriptorBuilder', () => {
         }).basePath).toBe('/foo/bar/');
     });
 
+    it('does not fail if there is not any server', () => {
+        expect(buildApiDescriptor({
+            ...emptyOpenApi,
+            servers: []
+        }).basePath).toBe('');
+    });
+
     it('Throws if using a default response', () => {
         expect(() => buildApiDescriptor({
             ...emptyOpenApi,

--- a/packages/openapi2typescript/src/plugins/react-fetching-library/ResponseInterceptor.ts
+++ b/packages/openapi2typescript/src/plugins/react-fetching-library/ResponseInterceptor.ts
@@ -51,7 +51,7 @@ const validateSchema =
         for (const rule of rules) {
             if (rule.status === response.status) {
                 const result = rule.zod.safeParse(response.payload);
-                if (!!result.success) {
+                if (result.success) {
                     return validatedResponse(
                         rule.type,
                         rule.status,


### PR DESCRIPTION
- More optional configuration props for delete/edit modals 
- New ci, qa, stage presets (ci => ci & ci-beta, etc)
- Adds SemiPartial type when we want to leave some props as is
- Does not fail if openapi-cli finds an empty servers