### PR TITLE
feat: allow to hide filters in the Primary Toolbar

### DIFF
--- a/packages/insights-common-typescript/src/types/Filters.ts
+++ b/packages/insights-common-typescript/src/types/Filters.ts
@@ -6,6 +6,8 @@ export type FilterContent = string | Array<string> | undefined;
 export type EnumElement<Enum> = Enum[keyof Enum];
 
 export type FilterBase<Enum extends StandardFilterEnum<any>, T> = Record<EnumElement<Enum>, T>;
+export type OptionalFilterBase<Enum extends StandardFilterEnum<any>, T> = FilterBase<Enum, T | undefined>;
+
 export type Filters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, FilterContent>;
 export type SetFilters<Enum extends StandardFilterEnum<any>> = FilterBase<Enum, Setter<FilterContent>>;
 export type ClearFilterElement<Enum extends StandardFilterEnum<any>> = {


### PR DESCRIPTION
This allows to have `undefined` entries in the primary toolbar config to hide some of the filters and show others.