### PR TITLE
feat: dropping ouia* and using from frontend-components

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -120,7 +120,9 @@ rules:
   max-len:
     - 2
     - 150
-  new-cap: 2
+  new-cap:
+    - error
+    - capIsNew: false
   no-bitwise: 2
   no-caller: 2
   no-console: off

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@patternfly/react-icons": "4.10.11",
     "@patternfly/react-table": "4.27.24",
     "@patternfly/react-tokens": "4.11.12",
-    "@redhat-cloud-services/frontend-components": "3.2.8",
+    "@redhat-cloud-services/frontend-components": "3.8.2",
     "@redhat-cloud-services/frontend-components-notifications": "3.2.2",
     "@redhat-cloud-services/frontend-components-utilities": "3.2.2",
     "@redhat-cloud-services/rbac-client": "1.0.98",

--- a/packages/insights-common-typescript/src/components/AppSkeleton/AppSkeleton.tsx
+++ b/packages/insights-common-typescript/src/components/AppSkeleton/AppSkeleton.tsx
@@ -6,16 +6,16 @@ import {
     PageHeaderTitle,
     Section,
     Skeleton,
-    Spinner
+    Spinner,
+    WithOuia
 } from '@redhat-cloud-services/frontend-components';
 import { Bullseye } from '@patternfly/react-core';
+import { ouiaParams } from '../../utils/Ouia';
 
-import { OuiaComponentProps, getOuiaProps } from '../../utils/Ouia';
-
-export const AppSkeleton: React.FunctionComponent<OuiaComponentProps> = (props) => {
+export const AppSkeleton = WithOuia(() => {
 
     return (
-        <div { ...getOuiaProps('AppSkeleton', props) }>
+        <>
             <PageHeader>
                 <div className="pf-c-content">
                     <PageHeaderTitle title={ <Skeleton size="sm"/> }/>
@@ -28,6 +28,6 @@ export const AppSkeleton: React.FunctionComponent<OuiaComponentProps> = (props) 
                     </Bullseye>
                 </Section>
             </Main>
-        </div>
+        </>
     );
-};
+}, ouiaParams('AppSkeleton'));

--- a/packages/insights-common-typescript/src/components/EmailOptIn/EmailOptIn.tsx
+++ b/packages/insights-common-typescript/src/components/EmailOptIn/EmailOptIn.tsx
@@ -3,39 +3,38 @@ import { Alert, AlertVariant, Text, TextContent } from '@patternfly/react-core';
 
 import { Messages } from '../../properties/Messages';
 import { Config } from '../../config';
-import { InsightsType, OuiaComponentProps } from '../../utils';
-import { getOuiaProps } from '../../utils/Ouia';
+import { InsightsType } from '../../utils';
+import { ouiaParams } from '../../utils/Ouia';
 import { format } from 'react-string-format';
+import { WithOuia } from '@redhat-cloud-services/frontend-components';
 
-interface EmailOptInProps extends OuiaComponentProps {
+interface EmailOptInProps {
     content: string;
     isBeta: boolean;
     bundle: string;
 }
 
-export const EmailOptIn: React.FunctionComponent<EmailOptInProps> = (props) => {
+export const EmailOptIn = WithOuia((props: EmailOptInProps) => {
     const emailUrl = React.useMemo(() => Config.pages.emailPreferences(props.isBeta, props.bundle), [ props.bundle, props.isBeta ]);
     const content = React.useMemo(() => {
         return format(props.content, <a href={ Config.pages.notificationSettings(props.isBeta, props.bundle) }>notification settings</a>);
     }, [ props.content, props.bundle, props.isBeta ]);
 
     return (
-        <div { ...getOuiaProps('EmailOptin', props) }>
-            <Alert
-                title={ Messages.components.emailOptIn.title }
-                variant={ AlertVariant.warning }
-                isInline={ true }
-            >
-                <TextContent>
-                    <Text>{ content }</Text>
-                    <Text>
-                        <a href={ emailUrl } target='_blank' rel='noopener noreferrer' >{ Messages.components.emailOptIn.link }</a>
-                    </Text>
-                </TextContent>
-            </Alert>
-        </div>
+        <Alert
+            title={ Messages.components.emailOptIn.title }
+            variant={ AlertVariant.warning }
+            isInline={ true }
+        >
+            <TextContent>
+                <Text>{ content }</Text>
+                <Text>
+                    <a href={ emailUrl } target='_blank' rel='noopener noreferrer' >{ Messages.components.emailOptIn.link }</a>
+                </Text>
+            </TextContent>
+        </Alert>
     );
-};
+}, ouiaParams('EmailOptin'));
 
 type Partials = 'isBeta' | 'bundle';
 type InsightsEmailOptInPropsType = Partial<Pick<EmailOptInProps, Partials>> & Omit<EmailOptInProps, Partials>;

--- a/packages/insights-common-typescript/src/components/EmptyState/EmptyState.tsx
+++ b/packages/insights-common-typescript/src/components/EmptyState/EmptyState.tsx
@@ -3,14 +3,14 @@ import { Button, EmptyState as EmptyStatePf, EmptyStateBody, EmptyStateIcon, Emp
 import { global_spacer_3xl } from '@patternfly/react-tokens';
 import { style } from 'typestyle';
 import { calc } from 'csx';
-import { OuiaComponentProps } from '../../utils';
-import { getOuiaProps } from '../../utils/Ouia';
+import { ouiaParams } from '../../utils/Ouia';
+import { WithOuia } from '@redhat-cloud-services/frontend-components';
 
 const emptyStateClassName = style({
     paddingTop: calc(`${ global_spacer_3xl.var } - var(--pf-c-page__main-section--PaddingTop)`)
 });
 
-export interface EmptyStateSectionProps extends OuiaComponentProps {
+export interface EmptyStateSectionProps {
     icon?: React.ComponentType<any>;
     iconColor?: string;
     title: string;
@@ -21,20 +21,18 @@ export interface EmptyStateSectionProps extends OuiaComponentProps {
     className?: string;
 }
 
-export const EmptyState: React.FunctionComponent<EmptyStateSectionProps> = (props) => (
-    <div { ...getOuiaProps('EmptyState', props) } >
-        <EmptyStatePf variant={ EmptyStateVariant.full } className={ `${emptyStateClassName} ${props.className ? props.className : ''} ` }>
-            { props.icon && <EmptyStateIcon icon={ props.icon } color={ props.iconColor } /> }
-            <Title headingLevel="h5" size="lg">
-                { props.title }
-            </Title>
-            <EmptyStateBody>
-                { props.content }
-            </EmptyStateBody>
-            { props.actionNode }
-            { props.actionLabel && (
-                <Button variant="primary" onClick={ props.action } isDisabled={ !props.action } >{ props.actionLabel }</Button>
-            ) }
-        </EmptyStatePf>
-    </div>
-);
+export const EmptyState = WithOuia((props: EmptyStateSectionProps) => (
+    <EmptyStatePf variant={ EmptyStateVariant.full } className={ `${emptyStateClassName} ${props.className ? props.className : ''} ` }>
+        { props.icon && <EmptyStateIcon icon={ props.icon } color={ props.iconColor } /> }
+        <Title headingLevel="h5" size="lg">
+            { props.title }
+        </Title>
+        <EmptyStateBody>
+            { props.content }
+        </EmptyStateBody>
+        { props.actionNode }
+        { props.actionLabel && (
+            <Button variant="primary" onClick={ props.action } isDisabled={ !props.action } >{ props.actionLabel }</Button>
+        ) }
+    </EmptyStatePf>
+), ouiaParams('EmptyState'));

--- a/packages/insights-common-typescript/src/components/ErrorBoundaryPage/ErrorBoundaryPage.tsx
+++ b/packages/insights-common-typescript/src/components/ErrorBoundaryPage/ErrorBoundaryPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Main, PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
+import { Main, PageHeader, PageHeaderTitle, WithOuia } from '@redhat-cloud-services/frontend-components';
 import { Messages } from '../../properties/Messages';
 import { ErrorCircleOIcon } from '@patternfly/react-icons';
 import { Text, ExpandableSection } from '@patternfly/react-core';
@@ -7,9 +7,9 @@ import { global_spacer_sm, global_BackgroundColor_dark_300 } from '@patternfly/r
 import { join } from '../../utils/ComponentUtils';
 import { style } from 'typestyle';
 import { EmptyState } from '../EmptyState/EmptyState';
-import { getOuiaProps, OuiaComponentProps } from '../../utils/Ouia';
+import { ouiaParams } from '../../utils/Ouia';
 
-interface ErrorPageProps extends OuiaComponentProps {
+interface ErrorPageProps {
     action: () => void;
     actionLabel: string;
     pageHeader: string;
@@ -70,7 +70,7 @@ const ErrorStack: React.FunctionComponent<ErrorStackProps> = (props) => {
 };
 
 // As of time of writing, React only supports error boundaries in class components
-export class ErrorBoundaryPage extends React.Component<ErrorPageProps, ErrorPageState> {
+class ErrorBoundaryPageInternal extends React.Component<ErrorPageProps, ErrorPageState> {
     constructor(props: Readonly<ErrorPageProps>) {
         super(props);
         this.state = {
@@ -93,7 +93,7 @@ export class ErrorBoundaryPage extends React.Component<ErrorPageProps, ErrorPage
     render() {
         if (this.state.hasError) {
             return (
-                <div { ...getOuiaProps('ErrorBoundaryPage', this.props) }>
+                <>
                     <PageHeader>
                         <PageHeaderTitle title={ this.props.pageHeader }/>
                     </PageHeader>
@@ -114,10 +114,12 @@ export class ErrorBoundaryPage extends React.Component<ErrorPageProps, ErrorPage
                             actionLabel={ this.props.actionLabel }
                         />
                     </Main>
-                </div>
+                </>
             );
         }
 
         return this.props.children;
     }
 }
+
+export const ErrorBoundaryPage = WithOuia(ErrorBoundaryPageInternal, ouiaParams('ErrorBoundaryPage'));

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/Checkbox.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/Checkbox.tsx
@@ -3,10 +3,10 @@ import { useField } from 'formik';
 import { Checkbox as PFCheckbox, FormGroup, CheckboxProps as PFCheckboxProps } from '@patternfly/react-core';
 
 import { onChangePFAdapter } from './Common';
-import { OuiaComponentProps } from '../../../utils';
-import { getOuiaProps, withoutOuiaProps } from '../../../utils/Ouia';
+import { ouiaParams } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
 
-interface CheckboxProps extends OuiaComponentProps, Omit<PFCheckboxProps, 'onChange' | 'ref'> {
+interface CheckboxProps extends OuiaProps, Omit<PFCheckboxProps, 'onChange' | 'ref'> {
     name: string;
     isRequired?: boolean;
 }
@@ -15,13 +15,15 @@ export const Checkbox: React.FunctionComponent<CheckboxProps> = (props) => {
     const [ field, meta ] = useField({ ...props, type: 'checkbox' });
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/Checkbox'));
+
     return (
         <FormGroup
             fieldId={ props.id }
             helperTextInvalid={ meta.error }
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
-            { ...getOuiaProps('FormikPatternfly/Checkbox', props) }
+            { ...ouiaData }
         >
             <PFCheckbox
                 isChecked={ field.checked  }

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/Form.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/Form.tsx
@@ -1,18 +1,20 @@
 import * as React from 'react';
 import { Form as PFForm, FormProps as PFFormProps } from '@patternfly/react-core';
-import { OuiaComponentProps } from '../../../utils';
-import { getOuiaProps, withoutOuiaProps } from '../../../utils/Ouia';
+import { ouiaParams } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
 
 const preventDefaultHandler = (e: React.FormEvent) => e.preventDefault();
 
-interface FormProps extends OuiaComponentProps, PFFormProps {
+interface FormProps extends OuiaProps, PFFormProps {
 
 }
 
 export const Form: React.FunctionComponent<FormProps> = (props) => {
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/Form'));
+
     return (
-        <PFForm onSubmit={ preventDefaultHandler } { ...withoutOuiaProps(props) }  { ...getOuiaProps('FormikPatternfly/Form', props) } >
+        <PFForm onSubmit={ preventDefaultHandler } { ...withoutOuiaProps(props) }  { ...ouiaData } >
             { props.children }
         </PFForm>
     );

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormSelect.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormSelect.tsx
@@ -3,10 +3,10 @@ import { useField } from 'formik';
 import { FormGroup, FormSelect as PFFormSelect, FormSelectProps as PFFormSelectProps } from '@patternfly/react-core';
 
 import { onChangePFAdapter } from './Common';
-import { OuiaComponentProps } from '../../../utils';
-import { getOuiaProps, withoutOuiaProps } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../../utils/Ouia';
 
-interface FormSelectProps extends OuiaComponentProps, Omit<PFFormSelectProps, 'onChange' | 'ref' | 'ouiaId'> {
+interface FormSelectProps extends OuiaProps, Omit<PFFormSelectProps, 'onChange' | 'ref' | 'ouiaId'> {
     id: string;
     name: string;
     isRequired?: boolean;
@@ -16,6 +16,8 @@ export const FormSelect: React.FunctionComponent<FormSelectProps> = (props) => {
     const [ field, meta ] = useField({ ...props });
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/FormSelect'));
+
     return (
         <FormGroup
             fieldId={ props.id }
@@ -23,7 +25,7 @@ export const FormSelect: React.FunctionComponent<FormSelectProps> = (props) => {
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
             label={ props.label }
-            { ...getOuiaProps('FormikPatternfly/FormSelect', props) }
+            { ...ouiaData }
         >
             <PFFormSelect
                 { ...withoutOuiaProps(props) }

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormText.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormText.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { useField } from 'formik';
 import { FormGroup, Text, TextVariants, TextProps } from '@patternfly/react-core';
-import { getOuiaProps, OuiaComponentProps, withoutOuiaProps } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../../utils/Ouia';
 
-interface FormTextProps extends OuiaComponentProps, Omit<TextProps, 'ref'> {
+interface FormTextProps extends OuiaProps, Omit<TextProps, 'ref'> {
     id: string;
     name: string;
     isRequired?: boolean;
@@ -13,6 +14,8 @@ export const FormText: React.FunctionComponent<FormTextProps> = (props) => {
     const [ field, meta ] = useField({ ...props });
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/FormText'));
+
     return (
         <FormGroup
             fieldId={ props.id }
@@ -20,7 +23,7 @@ export const FormText: React.FunctionComponent<FormTextProps> = (props) => {
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
             label={ props.label }
-            { ...getOuiaProps('FormikPatternfly/FormText', props) }
+            { ...ouiaData }
         >
             <Text component={ TextVariants.p }
                 { ...withoutOuiaProps(props) }

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextArea.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextArea.tsx
@@ -3,10 +3,10 @@ import { useField } from 'formik';
 import { FormGroup, TextArea as PFTextArea, TextAreaProps as PFTextAreaProps } from '@patternfly/react-core';
 
 import { onChangePFAdapter } from './Common';
-import { OuiaComponentProps, withoutOuiaProps } from '../../../utils';
-import { getOuiaProps } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../../utils/Ouia';
 
-interface FormTextAreaProps extends OuiaComponentProps, Omit<PFTextAreaProps, 'id' | 'name' | 'onChange'> {
+interface FormTextAreaProps extends OuiaProps, Omit<PFTextAreaProps, 'id' | 'name' | 'onChange'> {
     id: string;
     name: string;
 }
@@ -16,6 +16,8 @@ export const FormTextArea: React.FunctionComponent<FormTextAreaProps> = (props) 
     const [ field, meta ] = useField({ ...useFieldProps });
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/FormTextArea'));
+
     return (
         <FormGroup
             fieldId={ props.id }
@@ -23,7 +25,7 @@ export const FormTextArea: React.FunctionComponent<FormTextAreaProps> = (props) 
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
             label={ props.label }
-            { ...getOuiaProps('FormikPatternfly/FormTextArea', props) }
+            { ...ouiaData }
         >
             <PFTextArea
                 { ...withoutOuiaProps(props) }

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextInput.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextInput.tsx
@@ -3,10 +3,10 @@ import { useField } from 'formik';
 import { FormGroup, Text, TextInput as PFTextInput, TextInputProps, TextVariants } from '@patternfly/react-core';
 
 import { onChangePFAdapter } from './Common';
-import { OuiaComponentProps, withoutOuiaProps } from '../../../utils';
-import { getOuiaProps } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../../utils/Ouia';
 
-interface FormTextInputProps extends OuiaComponentProps, Omit<TextInputProps, 'onChange' | 'innerRef'> {
+interface FormTextInputProps extends OuiaProps, Omit<TextInputProps, 'onChange' | 'innerRef'> {
     id: string;
     name: string;
     hint?: string;
@@ -17,6 +17,8 @@ export const FormTextInput: React.FunctionComponent<FormTextInputProps> = (props
     const [ field, meta ] = useField({ ...otherProps });
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/FormTextInput'));
+
     return (
         <FormGroup
             fieldId={ props.id }
@@ -24,7 +26,7 @@ export const FormTextInput: React.FunctionComponent<FormTextInputProps> = (props
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
             label={ props.label }
-            { ...getOuiaProps('FormikPatternfly/FormTextInput', props) }
+            { ...ouiaData }
         >
             <PFTextInput
                 { ...withoutOuiaProps(otherProps) }

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/Switch.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/Switch.tsx
@@ -3,10 +3,10 @@ import { useField } from 'formik';
 import { FormGroup, Switch as PFSwitch, SwitchProps as PFSwitchProps } from '@patternfly/react-core';
 
 import { onChangePFAdapter } from './Common';
-import { OuiaComponentProps, withoutOuiaProps } from '../../../utils';
-import { getOuiaProps } from '../../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../../utils/Ouia';
 
-interface SwitchProps extends OuiaComponentProps, Omit<PFSwitchProps, 'onChange' | 'ref' | 'ouiaSafe' | 'ouiaId'> {
+interface SwitchProps extends OuiaProps, Omit<PFSwitchProps, 'onChange' | 'ref' | 'ouiaSafe' | 'ouiaId'> {
     id: string;
     name: string;
     isRequired?: boolean;
@@ -18,6 +18,8 @@ export const Switch: React.FunctionComponent<SwitchProps> = (props) => {
     const { labelOn: label, ...restProps } = props;
     const isValid = !meta.error || !meta.touched;
 
+    const ouiaData = useOuia(ouiaParams('FormikPatternfly/Switch'));
+
     return (
         <FormGroup
             fieldId={ props.id }
@@ -25,7 +27,7 @@ export const Switch: React.FunctionComponent<SwitchProps> = (props) => {
             isRequired={ props.isRequired }
             validated={ (isValid) ? 'default' : 'error' }
             label={ props.label }
-            { ...getOuiaProps('FormikPatternfly/Switch', props) }
+            { ...ouiaData }
         >
             <div>
                 <PFSwitch

--- a/packages/insights-common-typescript/src/components/FrontendComponents/Section.tsx
+++ b/packages/insights-common-typescript/src/components/FrontendComponents/Section.tsx
@@ -1,15 +1,15 @@
 import * as React from 'react';
-import { Section as IFCSection, DarkContext } from '@redhat-cloud-services/frontend-components';
+import { Section as IFCSection, DarkContext, useOuia, OuiaProps } from '@redhat-cloud-services/frontend-components';
 import { classes } from 'typestyle';
-import { OuiaComponentProps } from '../../utils';
-import { getOuiaProps } from '../../utils/Ouia';
+import { ouiaParams } from '../../utils/Ouia';
 
-interface SectionProps extends OuiaComponentProps {
+interface SectionProps extends OuiaProps {
     className?: string;
-    style?: React.CSSProperties;
 }
 
 export const Section: React.FunctionComponent<SectionProps> = (props) => {
+    const ouiaData = useOuia(ouiaParams('Section'));
+
     return (
         <DarkContext.Consumer>
             { (theme = 'light') => {
@@ -21,8 +21,7 @@ export const Section: React.FunctionComponent<SectionProps> = (props) => {
                     theme === 'light' ? 'pf-m-light' : ''
                 );
                 return <IFCSection
-                    { ...getOuiaProps('Section', props) }
-                    style={ props.style }
+                    { ...ouiaData }
                     className={ className }>
                     { props.children }
                 </IFCSection>;

--- a/packages/insights-common-typescript/src/components/Wrappers/BreadcrumbLinkItem.tsx
+++ b/packages/insights-common-typescript/src/components/Wrappers/BreadcrumbLinkItem.tsx
@@ -1,16 +1,18 @@
 import * as React from 'react';
 import { BreadcrumbItem, BreadcrumbItemProps } from '@patternfly/react-core';
 import { LinkAdapter } from './LinkAdapter';
-import { OuiaComponentProps, withoutOuiaProps } from '../../utils';
-import { getOuiaProps } from '../../utils/Ouia';
+import { OuiaProps, useOuia, withoutOuiaProps } from '@redhat-cloud-services/frontend-components';
+import { ouiaParams } from '../../utils/Ouia';
 
-type BreadcrumbLinkItemProps = Omit<BreadcrumbItemProps, 'component'> & OuiaComponentProps;
+type BreadcrumbLinkItemProps = Omit<BreadcrumbItemProps, 'component'> & OuiaProps;
 
 export const BreadcrumbLinkItem: React.FunctionComponent<BreadcrumbLinkItemProps> = (props) => {
+    const ouiaData = useOuia(ouiaParams('BreadcrumbLinkItem'));
+
     return (
         <BreadcrumbItem
             { ...withoutOuiaProps(props) }
-            { ...getOuiaProps('BreadcrumbLinkItem', props) }
+            { ...ouiaData }
             component={ LinkAdapter }
         >
             { props.children }

--- a/packages/insights-common-typescript/src/utils/Ouia.ts
+++ b/packages/insights-common-typescript/src/utils/Ouia.ts
@@ -1,55 +1,7 @@
-export interface OuiaComponentProps {
-    ouiaId?: string;
-    ouiaSafe?: boolean;
-}
+import { UseOuiaParams } from '@redhat-cloud-services/frontend-components';
 
-interface UseOuiaReturn {
-    'data-ouia-component-type': string;
-    'data-ouia-component-id'?: string;
-    'data-ouia-safe': boolean;
-}
-
-export const setOuiaPage = (type: string, action?: string, objectId?: string) => {
-    document.body.setAttribute('data-ouia-page-type', type);
-    if (action === undefined) {
-        document.body.removeAttribute('data-ouia-page-action');
-    } else {
-        document.body.setAttribute('data-ouia-page-action', action);
-    }
-
-    if (objectId === undefined) {
-        document.body.removeAttribute('data-ouia-page-object-id');
-    } else {
-        document.body.setAttribute('data-ouia-page-object-id', objectId);
-    }
-};
-
-export const getOuiaPropsFactory = (module: string) => (type: string, oiuaProps: OuiaComponentProps): UseOuiaReturn => {
-    const props = {
-        'data-ouia-component-type': `${module}/${type}`,
-        'data-ouia-safe': oiuaProps.ouiaSafe ?? true
-    };
-
-    if (oiuaProps.ouiaId) {
-        props['data-ouia-component-id'] = oiuaProps.ouiaId;
-    }
-
-    return props;
-};
-
-export const withoutOuiaProps = <T extends OuiaComponentProps>(props: T): Omit<T, 'ouiaId' | 'ouiaSafe'> => {
-    const { ouiaId, ouiaSafe, ...rest } = props;
-
-    return rest;
-};
-
-export const ouiaIdConcat = (ouiaIdParent: string | undefined, ouiaId: string) => {
-    if (ouiaIdParent) {
-        return `${ouiaIdParent}.${ouiaId}`;
-    }
-
-    return ouiaId;
-};
-
-// For internal use
-export const getOuiaProps = getOuiaPropsFactory('insights-common-typescript');
+// Used internally
+export const ouiaParams = (type: string): UseOuiaParams => ({
+    module: 'insights-common-typescript',
+    type
+});

--- a/packages/insights-common-typescript/src/utils/index.ts
+++ b/packages/insights-common-typescript/src/utils/index.ts
@@ -7,4 +7,3 @@ export * from './FetchingConfiguration';
 export * from './getBaseName';
 export * from './Insights';
 export * from './RbacUtils';
-export { OuiaComponentProps, getOuiaPropsFactory, setOuiaPage, withoutOuiaProps, ouiaIdConcat } from './Ouia';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1931,14 +1931,15 @@
     commander ">=2.20.0"
     react-content-loader ">=3.4.1"
 
-"@redhat-cloud-services/frontend-components@3.2.8":
-  version "3.2.8"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components/-/frontend-components-3.2.8.tgz#af4dee38e3c7787daaf53751e5ea0a35e9eb8a82"
-  integrity sha512-3593SbWe71p0OF/e6cqmiV3dC+zZrJqDzBMvDNvwFG1OoPvZYA/GfxI5fLTgHV589/9IWFZoFvn/3EoWqBBCyg==
+"@redhat-cloud-services/frontend-components@3.8.2":
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components/-/frontend-components-3.8.2.tgz#bc93cf05a1684c3d1d91612ee9aaf01d23d96d3f"
+  integrity sha512-hTR89+MGx7Rp/G5wYijtyp2Q+G8uet5DmGmVF4IAjcoXN9/vGWZ+JUCTctyFukGuLYbsoO+v7cct5vpHDpR5BA==
   dependencies:
     "@redhat-cloud-services/frontend-components-utilities" ">=3.0.0"
-    "@scalprum/core" "^0.0.11"
-    "@scalprum/react-core" "^0.0.16"
+    "@redhat-cloud-services/types" "0.0.1"
+    "@scalprum/core" "^0.1.1"
+    "@scalprum/react-core" "^0.1.7"
     sanitize-html "^2.3.2"
 
 "@redhat-cloud-services/insights-common-typescript@file:packages/insights-common-typescript":
@@ -1953,6 +1954,11 @@
   integrity sha512-R5xcoHs7EIdsbMhyXWWgAnkGf3WoLyd5tnpF/tos96pCUEsdXCCCkzDTdy8NqQT2SgLr1wjCorDHaDRuSdh9qA==
   dependencies:
     axios "^0.21.1"
+
+"@redhat-cloud-services/types@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/types/-/types-0.0.1.tgz#8c80b37d23aa2e7f54194926dea19fb890fc015d"
+  integrity sha512-UgHgLf8LkqaD9PXjiVyYycMRlbvmVdJyoJfersCUwnzDMgp+DEoYlLQAa9kn/s4c1JvSt5MM+hEN+DRvwtCQGA==
 
 "@rollup/plugin-commonjs@19.0.0":
   version "19.0.0"
@@ -2003,17 +2009,17 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@scalprum/core@^0.0.11":
-  version "0.0.11"
-  resolved "https://registry.yarnpkg.com/@scalprum/core/-/core-0.0.11.tgz#9d547d9ce1e344eba034ab03221e43cad455d2ff"
-  integrity sha512-iTXWltn+7x3uGghQ1gR4upZzu2ltILaTMA4zY54yUP/DqR9x5NpSlSZnjnVoyqZ1ftL2PjU7pPokt3fVv6phqQ==
+"@scalprum/core@^0.1.1", "@scalprum/core@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@scalprum/core/-/core-0.1.2.tgz#500bfd4d601a3718bc9b188a0eda8361a17c9034"
+  integrity sha512-dupFyb1niBpyy1Mb6+bSbhZhNGYGQ4T32iNNdLB6Pvey64bApSnXl7AFl2D8468xO1YTb4Bah1libovLWvZovQ==
 
-"@scalprum/react-core@^0.0.16":
-  version "0.0.16"
-  resolved "https://registry.yarnpkg.com/@scalprum/react-core/-/react-core-0.0.16.tgz#b7b9f9f7397dfb56b4a43b4dbce4511d69afc56e"
-  integrity sha512-VNsh3oBBvMjzm8ByTXiHkJCYwNgRbY9Apz2zVU+1rzZPtRRbjvvnRZTop5vcRa6CRMyttNNtSQ3R2n0EZlNBGg==
+"@scalprum/react-core@^0.1.7":
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/@scalprum/react-core/-/react-core-0.1.9.tgz#ebf05b5b5d69eaae0614673f16e73dc014ad8c25"
+  integrity sha512-lb6sQQp7eylEF8z6UIeGygzURWXJ+1dbQi2NXctp7EU8zJ/3vfDD3dDGp2YOjs1DEVrG6Byxjf5394jlBFB2Vw==
   dependencies:
-    "@scalprum/core" "^0.0.11"
+    "@scalprum/core" "^0.1.2"
     lodash "^4.17.0"
 
 "@sentry/browser@^5.4.0":


### PR DESCRIPTION
Similar to the ouia selectors, ouia code now lives in the frontend-components.

Dropping support here.