### PR TITLE
fix(onchange callback): change sending event instead of value

### DIFF
--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/Common.ts
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/Common.ts
@@ -1,8 +1,8 @@
 import * as React from 'react';
 import { FieldInputProps } from 'formik';
 
-export const onChangePFAdapter = <T = React.FormEvent<HTMLInputElement>, E = boolean>(field: FieldInputProps<T>) => {
-    return (_: T, e: E) => {
+export const onChangePFAdapter = <T = React.FormEvent<HTMLInputElement>>(field: FieldInputProps<T>) => {
+    return (e: T) => {
         return field.onChange(e);
     };
 };

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormSelect.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormSelect.tsx
@@ -28,7 +28,7 @@ export const FormSelect: React.FunctionComponent<FormSelectProps> = (props) => {
             <PFFormSelect
                 { ...withoutOuiaProps(props) }
                 { ...field }
-                onChange={ onChangePFAdapter<React.FormEvent<HTMLSelectElement>, string | number>(field) }
+                onChange={ onChangePFAdapter<React.FormEvent<HTMLSelectElement>>(field) }
                 isRequired={ props.isRequired }
                 validated={ (isValid) ? 'default' : 'error' }
             >

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextArea.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextArea.tsx
@@ -31,7 +31,7 @@ export const FormTextArea: React.FunctionComponent<FormTextAreaProps> = (props) 
                 value={ field.value || '' }
                 validated={ (isValid) ? 'default' : 'error' }
                 isRequired={ props.isRequired }
-                onChange={ onChangePFAdapter<React.FormEvent<HTMLTextAreaElement>, string | number>(field) }
+                onChange={ onChangePFAdapter<React.FormEvent<HTMLTextAreaElement>>(field) }
             />
             {meta.error && <FormHelperText>
                 <HelperText>

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextInput.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/FormTextInput.tsx
@@ -33,7 +33,7 @@ export const FormTextInput: React.FunctionComponent<FormTextInputProps> = (props
                 { ...field }
                 validated={ (isValid) ? 'default' : 'error' }
                 value={ field.value !== undefined ? field.value.toString() : '' }
-                onChange={ onChangePFAdapter<React.FormEvent<HTMLInputElement>, string | number>(field) }
+                onChange={ onChangePFAdapter<React.FormEvent<HTMLInputElement>>(field) }
             />
             { hint && <Text component={ TextVariants.small }>{ hint }</Text> }
             {meta.error && <FormHelperText>

--- a/packages/insights-common-typescript/src/components/Formik/Patternfly/Switch.tsx
+++ b/packages/insights-common-typescript/src/components/Formik/Patternfly/Switch.tsx
@@ -34,7 +34,7 @@ export const Switch: React.FunctionComponent<SwitchProps> = (props) => {
                     ouiaId="pf-switch"
                     ouiaSafe={ props.ouiaSafe }
                     label={ label }
-                    onChange={ onChangePFAdapter<React.FormEvent<HTMLInputElement>, boolean>(field) }
+                    onChange={ onChangePFAdapter<React.FormEvent<HTMLInputElement>>(field) }
                 />
                 {meta.error && <FormHelperText>
                     <HelperText>


### PR DESCRIPTION
### Description

Users are unable to type anything in TextInputs, this PR fixes it by passing correct values to onChange callback.