### PR TITLE
fix(RHINENG-15922): Additional fixes for middleware and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "react-use": "17.4.3",
     "redux": "4.1.0",
     "redux-logger": "3.0.6",
-    "redux-promise-middleware": "5.1.1",
+    "redux-promise-middleware": "^6.2.0",
     "rimraf": "3.0.2",
     "rollup": "2.52.0",
     "rollup-plugin-dts": "3.0.2",

--- a/packages/insights-common-typescript/src/components/Beta/__tests__/BetaDetector.test.tsx
+++ b/packages/insights-common-typescript/src/components/Beta/__tests__/BetaDetector.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { InsightsType, BetaDetector, BetaIf, BetaIfNot, InsightsBetaDetector } from '../../..';
+import '@testing-library/jest-dom';
 
 describe('src/components/Beta', () => {
 

--- a/packages/insights-common-typescript/src/components/EmailOptIn/__tests__/EmailOptIn.test.tsx
+++ b/packages/insights-common-typescript/src/components/EmailOptIn/__tests__/EmailOptIn.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { EmailOptIn, InsightsEmailOptIn } from '../EmailOptIn';
+import '@testing-library/jest-dom';
 
 describe('src/components/EmailOptIn', () => {
     it('Builds link for beta', () => {

--- a/packages/insights-common-typescript/src/components/Modals/__tests__/DeleteModal.test.tsx
+++ b/packages/insights-common-typescript/src/components/Modals/__tests__/DeleteModal.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import jestMock from 'jest-mock';
 import { ouiaSelectors } from 'insights-common-typescript-dev';
 import { DeleteModal } from '../..';
+import '@testing-library/jest-dom';
 
 describe('src/components/Modals/DeleteModal', () => {
     it('Shows action modal with Delete action button', () => {

--- a/packages/insights-common-typescript/src/components/Modals/__tests__/SaveModal.test.tsx
+++ b/packages/insights-common-typescript/src/components/Modals/__tests__/SaveModal.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react';
 import jestMock from 'jest-mock';
 import { ouiaSelectors } from 'insights-common-typescript-dev';
 import { SaveModal } from '../..';
+import '@testing-library/jest-dom';
 
 describe('src/components/Modals/SaveModal', () => {
     it('Shows action modal with Save action button', () => {

--- a/packages/insights-common-typescript/src/store/index.ts
+++ b/packages/insights-common-typescript/src/store/index.ts
@@ -15,7 +15,7 @@ export const initStore = <State, Reducer extends Record<string, any>>(initialSta
     }
 
     registry = new ReducerRegistry(initialState ?? {}, [
-        promiseMiddleware(),
+        promiseMiddleware,
         ...middleware
     ]);
 

--- a/packages/insights-common-typescript/src/utils/__tests__/Ouia.test.ts
+++ b/packages/insights-common-typescript/src/utils/__tests__/Ouia.test.ts
@@ -1,5 +1,6 @@
 import { getOuiaPropsFactory, ouiaIdConcat, setOuiaPage, withoutOuiaProps } from '../..';
 import { getOuiaProps } from '../Ouia';
+import '@testing-library/jest-dom';
 
 describe('src/utils/Ouia.test.ts', () => {
     describe('setOuiaPage', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9889,15 +9889,15 @@ redux-logger@3.0.6:
   dependencies:
     deep-diff "^0.3.5"
 
-redux-promise-middleware@5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/redux-promise-middleware/-/redux-promise-middleware-5.1.1.tgz#37689339a58a33d1fda675ed1ba2053a2d196b8d"
-  integrity sha512-YC1tiheU28Hgmtu5HHMLiuveLgjL1aCJWsSnwquMiZBcj5i/J9qVLt6vgOnb0Gz37y4deJ/rjiNt7l6Dh+Z8lA==
-
 redux-promise-middleware@6.1.3:
   version "6.1.3"
   resolved "https://registry.yarnpkg.com/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz#315f6a9fcabe1f02a9c2f30fa615f838d7b01b66"
   integrity sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==
+
+redux-promise-middleware@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/redux-promise-middleware/-/redux-promise-middleware-6.2.0.tgz#d139dfef50992d456860f8cf07a12085bd53f89d"
+  integrity sha512-TEzfMeLX63gju2WqkdFQlQMvUGYzFvJNePIJJsBlbPHs3Txsbc/5Rjhmtha1XdMU6lkeiIlp1Qx7AR3Zo9he9g==
 
 redux@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
This is an extra PR to address the `middleware is not a function` build error. This was caused by improper passing of promiseMiddleware to ReducerRegistry while creating a store.

Also, it fixes some tests that started to fail after jest related packages upgrade. Every test that utilises jest advanced assertions should import additional package in the beginning of test module.